### PR TITLE
Fixed fastapi pip installation as fastapi 0.55.1 requires starlette 0…

### DIFF
--- a/theHarvester/lib/app/requirements.txt
+++ b/theHarvester/lib/app/requirements.txt
@@ -14,7 +14,7 @@ requests==2.23.0
 retrying==1.3.3
 shodan==1.23.0
 slowapi==0.1.1
-starlette==0.13.4
+starlette==0.13.2
 texttable==1.6.2
 lxml==4.5.1
 uvicorn==0.11.5


### PR DESCRIPTION
….13.2