### PR TITLE
Complete Wayback CDX pagination

### DIFF
--- a/tests/discovery/test_waybackarchive.py
+++ b/tests/discovery/test_waybackarchive.py
@@ -1,3 +1,4 @@
+import logging
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -94,7 +95,7 @@ async def test_process_normalizes_the_requested_domain(monkeypatch: pytest.Monke
 
 @pytest.mark.asyncio
 async def test_process_keeps_partial_results_when_a_later_page_times_out(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
         query = parse_qs(urlparse(urls[0]).query)
@@ -107,10 +108,11 @@ async def test_process_keeps_partial_results_when_a_later_page_times_out(
     monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
 
     search = waybackarchive.SearchWaybackarchive('example.com')
-    await search.process()
+    with caplog.at_level(logging.WARNING, logger=waybackarchive.__name__):
+        await search.process()
 
     assert await search.get_hostnames() == {'api.example.com', 'example.com'}
-    assert 'Wayback Archive API error for pattern *.example.com' in capsys.readouterr().out
+    assert 'Wayback Archive API error for pattern *.example.com' in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/discovery/test_waybackarchive.py
+++ b/tests/discovery/test_waybackarchive.py
@@ -1,0 +1,149 @@
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from theHarvester.discovery import waybackarchive
+
+
+@pytest.mark.asyncio
+async def test_process_collects_more_than_one_cdx_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    first_page = '\n'.join(f'https://host-{index}.example.com/path' for index in range(100))
+    second_page = '\n'.join(f'https://host-{index}.example.com/path' for index in range(100, 125))
+    requests: list[dict[str, list[str]]] = []
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
+        query = parse_qs(urlparse(urls[0]).query)
+        requests.append(query)
+        if query['url'] == ['*.example.com']:
+            return [f'{first_page}\n\nnext-page'] if 'resumeKey' not in query else [second_page]
+        return ['']
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = waybackarchive.SearchWaybackarchive('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == {f'host-{index}.example.com' for index in range(125)}
+    assert [query.get('resumeKey') for query in requests if query['url'] == ['*.example.com']] == [None, ['next-page']]
+    assert all(query['showResumeKey'] == ['true'] for query in requests)
+
+
+@pytest.mark.asyncio
+async def test_process_stops_when_a_resume_key_repeats(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[dict[str, list[str]]] = []
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
+        query = parse_qs(urlparse(urls[0]).query)
+        requests.append(query)
+        if query['url'] == ['*.example.com']:
+            return ['https://api.example.com/path\n\nrepeated-key']
+        return ['']
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = waybackarchive.SearchWaybackarchive('example.com')
+    await search.process()
+
+    wildcard_requests = [query for query in requests if query['url'] == ['*.example.com']]
+    assert len(wildcard_requests) == 2
+    assert await search.get_hostnames() == {'api.example.com'}
+
+
+@pytest.mark.asyncio
+async def test_process_normalizes_and_scope_checks_each_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = '\n'.join(
+        (
+            'HTTPS://API.Example.COM:8443/path',
+            'https://example.com/root',
+            'https://notexample.com/path',
+            'https://example.com.attacker.net/path',
+            'https://bad host.example.com/path',
+            'malformed row',
+        )
+    )
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
+        query = parse_qs(urlparse(urls[0]).query)
+        return [payload] if query['url'] == ['*.example.com'] else ['']
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = waybackarchive.SearchWaybackarchive('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com', 'example.com'}
+
+
+@pytest.mark.asyncio
+async def test_process_normalizes_the_requested_domain(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[dict[str, list[str]]] = []
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
+        query = parse_qs(urlparse(urls[0]).query)
+        requests.append(query)
+        return ['https://api.example.com/path'] if query['url'] == ['*.example.com'] else ['']
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = waybackarchive.SearchWaybackarchive('Example.COM.')
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com'}
+    assert requests[0]['url'] == ['*.example.com']
+
+
+@pytest.mark.asyncio
+async def test_process_keeps_partial_results_when_a_later_page_times_out(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
+        query = parse_qs(urlparse(urls[0]).query)
+        if query['url'] == ['*.example.com']:
+            if 'resumeKey' in query:
+                raise TimeoutError
+            return ['https://api.example.com/path\n\nnext-page']
+        return ['https://example.com/path']
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = waybackarchive.SearchWaybackarchive('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com', 'example.com'}
+    assert 'Wayback Archive API error for pattern *.example.com' in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('payload', ['', '<html>provider error</html>', {'unexpected': 'shape'}])
+async def test_process_ignores_empty_html_and_non_text_responses(monkeypatch: pytest.MonkeyPatch, payload: object) -> None:
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        return [payload]
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = waybackarchive.SearchWaybackarchive('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == set()
+
+
+@pytest.mark.asyncio
+async def test_process_respects_the_per_query_page_bound(monkeypatch: pytest.MonkeyPatch) -> None:
+    wildcard_requests = 0
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[str]:
+        nonlocal wildcard_requests
+        query = parse_qs(urlparse(urls[0]).query)
+        if query['url'] == ['*.example.com']:
+            wildcard_requests += 1
+            return [f'https://host-{wildcard_requests}.example.com/path\n\npage-{wildcard_requests}']
+        return ['']
+
+    monkeypatch.setattr(waybackarchive.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    monkeypatch.setattr(waybackarchive.SearchWaybackarchive, 'MAX_PAGES_PER_QUERY', 2)
+
+    search = waybackarchive.SearchWaybackarchive('example.com')
+    await search.process()
+
+    assert wildcard_requests == 2
+    assert await search.get_hostnames() == {'host-1.example.com', 'host-2.example.com'}

--- a/theHarvester/discovery/waybackarchive.py
+++ b/theHarvester/discovery/waybackarchive.py
@@ -1,4 +1,4 @@
-import re
+from urllib.parse import urlencode, urlsplit
 
 from theHarvester.lib.core import AsyncFetcher, Core
 
@@ -6,8 +6,12 @@ from theHarvester.lib.core import AsyncFetcher, Core
 class SearchWaybackarchive:
     """Class uses Internet Archive's Wayback Machine CDX API to find historical subdomains"""
 
+    PAGE_SIZE = 1000
+    # Limits a single wildcard or root query to one million rows if the provider never terminates pagination.
+    MAX_PAGES_PER_QUERY = 1000
+
     def __init__(self, word) -> None:
-        self.word = word
+        self.word = word.strip().rstrip('.').lower()
         self.totalhosts: set = set()
         self.proxy = False
         self.hostname = 'https://web.archive.org'
@@ -16,52 +20,76 @@ class SearchWaybackarchive:
         """Extract domain from URL"""
         if not url:
             return ''
+        try:
+            parsed = urlsplit(url if '://' in url else f'//{url}')
+            hostname = (parsed.hostname or '').rstrip('.').lower()
+        except ValueError:
+            return ''
+        if len(hostname) > 253 or any(
+            not label
+            or len(label) > 63
+            or label.startswith('-')
+            or label.endswith('-')
+            or not all(character.isascii() and (character.isalnum() or character == '-') for character in label)
+            for label in hostname.split('.')
+        ):
+            return ''
+        return hostname
 
-        # Remove protocol
-        url = re.sub(r'^https?://', '', url)
+    @staticmethod
+    def _parse_page(payload: str) -> tuple[list[str], str | None]:
+        if not isinstance(payload, str) or payload.lstrip().startswith('<'):
+            return [], None
 
-        # Extract domain part (before first /)
-        domain = url.split('/')[0]
+        body, separator, continuation = payload.replace('\r\n', '\n').rpartition('\n\n')
+        if not separator:
+            return payload.splitlines(), None
 
-        # Remove port if present
-        domain = domain.split(':')[0]
+        continuation_lines = [line.strip() for line in continuation.splitlines() if line.strip()]
+        return body.splitlines(), continuation_lines[0] if len(continuation_lines) == 1 else None
 
-        return domain.lower()
+    async def _search_pattern(self, pattern: str, headers: dict[str, str]) -> None:
+        resume_key: str | None = None
+        seen_resume_keys: set[str] = set()
+        for _ in range(self.MAX_PAGES_PER_QUERY):
+            query = {
+                'url': pattern,
+                'fl': 'original',
+                'collapse': 'urlkey',
+                'limit': self.PAGE_SIZE,
+                'showResumeKey': 'true',
+            }
+            if resume_key is not None:
+                query['resumeKey'] = resume_key
+
+            url = f'{self.hostname}/cdx/search/cdx?{urlencode(query)}'
+            response = await AsyncFetcher.fetch_all([url], headers=headers, proxy=self.proxy)
+            if not response or not isinstance(response, list) or not response[0]:
+                return
+
+            lines, next_resume_key = self._parse_page(response[0])
+            for line in lines:
+                if not line:
+                    continue
+                domain = self._extract_domain_from_url(line.strip())
+                if domain.endswith(f'.{self.word}') or domain == self.word:
+                    self.totalhosts.add(domain)
+
+            if next_resume_key is None or next_resume_key in seen_resume_keys:
+                return
+            seen_resume_keys.add(next_resume_key)
+            resume_key = next_resume_key
 
     async def do_search(self) -> None:
         try:
             headers = {'User-agent': Core.get_user_agent()}
 
-            # Search for subdomains in wayback machine
-            # Using different approaches due to API timeout issues
-
-            # Method 1: Search for wildcard subdomains (limited results to avoid timeout)
-            urls_to_try = [
-                f'{self.hostname}/cdx/search/cdx?url=*.{self.word}&fl=original&collapse=urlkey&limit=100',
-                f'{self.hostname}/cdx/search/cdx?url={self.word}/*&fl=original&collapse=urlkey&limit=50',
-            ]
-
-            for url in urls_to_try:
+            for pattern in (f'*.{self.word}', f'{self.word}/*'):
                 try:
-                    response = await AsyncFetcher.fetch_all([url], headers=headers, proxy=self.proxy)
-
-                    if not response or not isinstance(response, list) or not response[0]:
-                        continue
-
-                    # Parse line-by-line response (not JSON)
-                    lines = response[0].strip().split('\n') if isinstance(response[0], str) else []
-
-                    for line in lines:
-                        if line and not line.startswith('<'):  # Skip HTML error messages
-                            # Each line is a URL
-                            domain = self._extract_domain_from_url(line.strip())
-
-                            # Check if it's a subdomain of our target
-                            if domain.endswith(f'.{self.word}') or domain == self.word:
-                                self.totalhosts.add(domain)
+                    await self._search_pattern(pattern, headers)
 
                 except Exception as e:
-                    print(f'Wayback Archive API error for URL {url}: {e}')
+                    print(f'Wayback Archive API error for pattern {pattern}: {e}')
                     continue
 
         except Exception as e:

--- a/theHarvester/discovery/waybackarchive.py
+++ b/theHarvester/discovery/waybackarchive.py
@@ -1,6 +1,9 @@
+import logging
 from urllib.parse import urlencode, urlsplit
 
 from theHarvester.lib.core import AsyncFetcher, Core
+
+logger = logging.getLogger(__name__)
 
 
 class SearchWaybackarchive:
@@ -89,11 +92,11 @@ class SearchWaybackarchive:
                     await self._search_pattern(pattern, headers)
 
                 except Exception as e:
-                    print(f'Wayback Archive API error for pattern {pattern}: {e}')
+                    logger.warning('Wayback Archive API error for pattern %s: %s', pattern, e)
                     continue
 
         except Exception as e:
-            print(f'Wayback Archive API error: {e}')
+            logger.error('Wayback Archive API error: %s', e)
 
     async def get_hostnames(self) -> set:
         return self.totalhosts


### PR DESCRIPTION
## Summary

- follow Wayback CDX resume-key pagination
- bound pagination and validate returned hostnames
- retain results across all fetched pages

## Validation

`uv run pytest tests/discovery/test_waybackarchive.py`

Result: 9 passed.

