### PR TITLE
Enumerate all Cert Spotter pages

### DIFF
--- a/tests/discovery/test_certspotter.py
+++ b/tests/discovery/test_certspotter.py
@@ -1,3 +1,4 @@
+import logging
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -140,7 +141,7 @@ async def test_process_stops_when_the_provider_repeats_a_cursor(monkeypatch: pyt
 
 @pytest.mark.asyncio
 async def test_process_reports_incomplete_results_at_the_request_safety_limit(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     monkeypatch.setattr(certspottersearch.SearchCertspoter, 'MAX_PAGES', 2)
     requested_urls: list[str] = []
@@ -153,8 +154,9 @@ async def test_process_reports_incomplete_results_at_the_request_safety_limit(
     monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
 
     search = certspottersearch.SearchCertspoter('example.com')
-    await search.process()
+    with caplog.at_level(logging.WARNING, logger=certspottersearch.__name__):
+        await search.process()
 
     assert await search.get_hostnames() == {'page-1.example.com', 'page-2.example.com'}
     assert len(requested_urls) == 2
-    assert 'results may be incomplete' in capsys.readouterr().out
+    assert 'results may be incomplete' in caplog.text

--- a/tests/discovery/test_certspotter.py
+++ b/tests/discovery/test_certspotter.py
@@ -1,40 +1,160 @@
-#!/usr/bin/env python3
-# coding=utf-8
-import os
-from typing import Optional
+from urllib.parse import parse_qs, urlparse
 
 import pytest
-import httpx
 
 from theHarvester.discovery import certspottersearch
-from theHarvester.lib.core import *
-
-github_ci: Optional[str] = os.getenv(
-    "GITHUB_ACTIONS"
-)  # Github set this to be the following: true instead of True
 
 
-class TestCertspotter(object):
-    @staticmethod
-    def domain() -> str:
-        return "metasploit.com"
+@pytest.mark.asyncio
+async def test_process_collects_normalized_scoped_names_across_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    pages = [
+        [
+            {
+                'id': 'issuance-1',
+                'dns_names': [
+                    'WWW.Example.COM.',
+                    '*.API.example.com',
+                    'example.com',
+                    'outside.test',
+                    None,
+                    ' ',
+                ],
+            },
+            {'id': 'issuance-2', 'dns_names': ['www.example.com']},
+        ],
+        [{'id': 'issuance-3', 'dns_names': ['mail.example.com', '*.deep.example.com']}],
+        [],
+    ]
+    requested_urls: list[str] = []
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        requested_urls.extend(urls)
+        return [pages.pop(0)]
+
+    monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = certspottersearch.SearchCertspoter('Example.COM.')
+    await search.process(proxy=True)
+
+    assert await search.get_hostnames() == {
+        'api.example.com',
+        'deep.example.com',
+        'example.com',
+        'mail.example.com',
+        'www.example.com',
+    }
+    assert [parse_qs(urlparse(url).query) for url in requested_urls] == [
+        {'domain': ['example.com'], 'include_subdomains': ['true'], 'expand': ['dns_names']},
+        {
+            'domain': ['example.com'],
+            'include_subdomains': ['true'],
+            'expand': ['dns_names'],
+            'after': ['issuance-2'],
+        },
+        {
+            'domain': ['example.com'],
+            'include_subdomains': ['true'],
+            'expand': ['dns_names'],
+            'after': ['issuance-3'],
+        },
+    ]
 
 
-@pytest.mark.skipif(github_ci == 'true', reason="Skipping this test for now")
-class TestCertspotterSearch(object):
-    @pytest.mark.asyncio
-    async def test_api(self) -> None:
-        base_url = f"https://api.certspotter.com/v1/issuances?domain={TestCertspotter.domain()}&expand=dns_names"
-        headers = {"User-Agent": Core.get_user_agent()}
-        request = httpx.get(base_url, headers=headers)
-        assert request.status_code == 200
+@pytest.mark.asyncio
+@pytest.mark.parametrize('response', [[], [''], [None], [{'code': 'rate_limited'}]])
+async def test_process_returns_empty_results_for_empty_malformed_or_error_responses(
+    monkeypatch: pytest.MonkeyPatch, response: list[object]
+) -> None:
+    async def fake_fetch_all(_urls: list[str], **_kwargs: object) -> list[object]:
+        return response
 
-    @pytest.mark.asyncio
-    async def test_search(self) -> None:
-        search = certspottersearch.SearchCertspoter(TestCertspotter.domain())
-        await search.process()
-        assert isinstance(await search.get_hostnames(), set)
+    monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = certspottersearch.SearchCertspoter('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == set()
 
 
-if __name__ == "__main__":
-    pytest.main()
+@pytest.mark.asyncio
+async def test_process_skips_malformed_entries_but_keeps_valid_page_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    pages = [
+        [
+            None,
+            {'id': 'ignored', 'dns_names': 'not-a-list'},
+            {'id': 'cursor-1', 'dns_names': ['valid.example.com']},
+        ],
+        [],
+    ]
+
+    async def fake_fetch_all(_urls: list[str], **_kwargs: object) -> list[object]:
+        return [pages.pop(0)]
+
+    monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = certspottersearch.SearchCertspoter('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == {'valid.example.com'}
+
+
+@pytest.mark.asyncio
+async def test_process_preserves_completed_pages_when_a_later_request_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    call_count = 0
+
+    async def fake_fetch_all(_urls: list[str], **_kwargs: object) -> list[object]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return [[{'id': 'cursor-1', 'dns_names': ['valid.example.com']}]]
+        raise ConnectionError
+
+    monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = certspottersearch.SearchCertspoter('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == {'valid.example.com'}
+
+
+@pytest.mark.asyncio
+async def test_process_stops_when_the_provider_repeats_a_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    pages = [
+        [{'id': 'repeated', 'dns_names': ['first.example.com']}],
+        [{'id': 'repeated', 'dns_names': ['second.example.com']}],
+    ]
+    requested_urls: list[str] = []
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        requested_urls.extend(urls)
+        return [pages.pop(0)]
+
+    monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = certspottersearch.SearchCertspoter('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == {'first.example.com', 'second.example.com'}
+    assert len(requested_urls) == 2
+
+
+@pytest.mark.asyncio
+async def test_process_reports_incomplete_results_at_the_request_safety_limit(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(certspottersearch.SearchCertspoter, 'MAX_PAGES', 2)
+    requested_urls: list[str] = []
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        requested_urls.extend(urls)
+        page_number = len(requested_urls)
+        return [[{'id': f'cursor-{page_number}', 'dns_names': [f'page-{page_number}.example.com']}]]
+
+    monkeypatch.setattr(certspottersearch.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = certspottersearch.SearchCertspoter('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == {'page-1.example.com', 'page-2.example.com'}
+    assert len(requested_urls) == 2
+    assert 'results may be incomplete' in capsys.readouterr().out

--- a/theHarvester/discovery/certspottersearch.py
+++ b/theHarvester/discovery/certspottersearch.py
@@ -1,38 +1,75 @@
+from urllib.parse import urlencode
+
 from theHarvester.lib.core import AsyncFetcher
 
 
 class SearchCertspoter:
-    def __init__(self, word) -> None:
-        self.word = word
-        self.totalhosts: set = set()
+    # Bound one-shot enumeration if a provider keeps returning novel cursors forever;
+    # exhausting the bound is reported as incomplete rather than silent success.
+    MAX_PAGES = 1_000
+
+    def __init__(self, target_domain: str) -> None:
+        self.target_domain = target_domain.strip().lower().rstrip('.')
+        self.totalhosts: set[str] = set()
         self.proxy = False
 
+    def _normalize_hostname(self, hostname: object) -> str | None:
+        if not isinstance(hostname, str):
+            return None
+
+        hostname = hostname.strip().lower().rstrip('.').removeprefix('*.')
+        if not hostname or '*' in hostname or any(character.isspace() for character in hostname):
+            return None
+        if hostname == self.target_domain or hostname.endswith(f'.{self.target_domain}'):
+            return hostname
+        return None
+
     async def do_search(self) -> None:
-        base_url = f'https://api.certspotter.com/v1/issuances?domain={self.word}&expand=dns_names'
+        base_url = 'https://api.certspotter.com/v1/issuances'
+        cursor = None
+        seen_cursors: set[str] = set()
         try:
-            response = await AsyncFetcher.fetch_all([base_url], json=True, proxy=self.proxy)
-            response = response[0]
-            if isinstance(response, list):
-                for dct in response:
-                    for key, value in dct.items():
-                        if key == 'dns_names':
-                            self.totalhosts.update({name for name in value if isinstance(name, str) and name})
-            elif isinstance(response, dict):
-                dns_names = response.get('dns_names')
-                if isinstance(dns_names, list):
-                    self.totalhosts.update({name for name in dns_names if isinstance(name, str) and name})
-                elif isinstance(dns_names, str) and dns_names:
-                    self.totalhosts.add(dns_names)
+            for _ in range(self.MAX_PAGES):
+                params = {
+                    'domain': self.target_domain,
+                    'include_subdomains': 'true',
+                    'expand': 'dns_names',
+                }
+                if cursor is not None:
+                    params['after'] = cursor
+
+                responses = await AsyncFetcher.fetch_all([f'{base_url}?{urlencode(params)}'], json=True, proxy=self.proxy)
+                if not responses or not isinstance(responses[0], list):
+                    break
+
+                page = responses[0]
+                if not page:
+                    break
+
+                for issuance in page:
+                    if not isinstance(issuance, dict):
+                        continue
+                    dns_names = issuance.get('dns_names')
+                    if not isinstance(dns_names, list):
+                        continue
+                    for dns_name in dns_names:
+                        if hostname := self._normalize_hostname(dns_name):
+                            self.totalhosts.add(hostname)
+
+                last_issuance = page[-1]
+                next_cursor = last_issuance.get('id') if isinstance(last_issuance, dict) else None
+                if not isinstance(next_cursor, str) or not next_cursor or next_cursor in seen_cursors:
+                    break
+                seen_cursors.add(next_cursor)
+                cursor = next_cursor
             else:
-                self.totalhosts.update({''})
-        except IndexError:
-            print('No data returned from Cert Spotter.')
+                print(f'Cert Spotter stopped after {self.MAX_PAGES} pages; results may be incomplete.')
         except ConnectionError:
             print('Network connection failed.')
         except Exception as e:
             print(f'Unexpected error occurred: {e}')
 
-    async def get_hostnames(self) -> set:
+    async def get_hostnames(self) -> set[str]:
         return self.totalhosts
 
     async def process(self, proxy: bool = False) -> None:

--- a/theHarvester/discovery/certspottersearch.py
+++ b/theHarvester/discovery/certspottersearch.py
@@ -1,6 +1,9 @@
+import logging
 from urllib.parse import urlencode
 
 from theHarvester.lib.core import AsyncFetcher
+
+logger = logging.getLogger(__name__)
 
 
 class SearchCertspoter:
@@ -63,11 +66,11 @@ class SearchCertspoter:
                 seen_cursors.add(next_cursor)
                 cursor = next_cursor
             else:
-                print(f'Cert Spotter stopped after {self.MAX_PAGES} pages; results may be incomplete.')
+                logger.warning('Cert Spotter stopped after %s pages; results may be incomplete.', self.MAX_PAGES)
         except ConnectionError:
-            print('Network connection failed.')
+            logger.warning('Cert Spotter network connection failed.')
         except Exception as e:
-            print(f'Unexpected error occurred: {e}')
+            logger.error('Unexpected Cert Spotter error: %s', e, exc_info=logger.isEnabledFor(logging.INFO))
 
     async def get_hostnames(self) -> set[str]:
         return self.totalhosts


### PR DESCRIPTION
## Summary

- follow Cert Spotter cursor pagination
- normalize and scope-filter discovered names
- enforce a bounded page limit

## Validation

`uv run pytest tests/discovery/test_certspotter.py`

Result: 9 passed.
