### PR TITLE
Retain typed DNS evidence

### DIFF
--- a/tests/lib/test_hostchecker.py
+++ b/tests/lib/test_hostchecker.py
@@ -1,0 +1,142 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from theHarvester.lib import hostchecker
+
+
+@pytest.mark.asyncio
+async def test_check_excludes_candidate_without_dns_evidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResolver:
+        async def query_dns(self, host: str, record_type: str):
+            if host == 'missing.example.com' or record_type != 'A':
+                raise OSError('not found')
+            record = SimpleNamespace(data=SimpleNamespace(addr='192.0.2.10'))
+            return SimpleNamespace(answer=[record])
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', lambda **_kwargs: FakeResolver())
+
+    checker = hostchecker.Checker(['found.example.com', 'missing.example.com'], nameservers=[])
+
+    resolved, hosts, addresses = await checker.check()
+
+    assert resolved == ['found.example.com:192.0.2.10']
+    assert hosts == ['found.example.com']
+    assert addresses == ['192.0.2.10']
+    assert checker.evidence['found.example.com'].ipv4 == ('192.0.2.10',)
+
+
+@pytest.mark.asyncio
+async def test_check_retains_aaaa_only_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResolver:
+        async def query_dns(self, _host: str, record_type: str):
+            if record_type == 'AAAA':
+                record = SimpleNamespace(data=SimpleNamespace(addr='2001:0db8::10'))
+                return SimpleNamespace(answer=[record])
+            raise OSError('no data')
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', lambda **_kwargs: FakeResolver())
+
+    checker = hostchecker.Checker(['ipv6.example.com'], nameservers=[])
+
+    resolved, hosts, addresses = await checker.check()
+
+    assert resolved == ['ipv6.example.com:2001:db8::10']
+    assert hosts == ['ipv6.example.com']
+    assert addresses == ['2001:db8::10']
+
+
+@pytest.mark.asyncio
+async def test_check_retains_cname_only_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResolver:
+        async def query_dns(self, _host: str, record_type: str):
+            if record_type == 'CNAME':
+                record = SimpleNamespace(data=SimpleNamespace(cname='Target.Example.NET.'))
+                return SimpleNamespace(answer=[record])
+            raise OSError('no data')
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', lambda **_kwargs: FakeResolver())
+
+    checker = hostchecker.Checker(['alias.example.com'], nameservers=[])
+
+    resolved, hosts, addresses = await checker.check()
+
+    assert resolved == ['alias.example.com']
+    assert hosts == ['alias.example.com']
+    assert addresses == []
+    assert checker.evidence['alias.example.com'].cnames == ('target.example.net',)
+
+
+@pytest.mark.asyncio
+async def test_check_normalizes_and_deduplicates_mixed_evidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    values = {
+        'A': [('addr', '192.0.2.10'), ('addr', '192.0.2.10')],
+        'AAAA': [('addr', '2001:0db8::10'), ('addr', '2001:db8:0:0::10')],
+        'CNAME': [('cname', 'Target.Example.NET.'), ('cname', 'target.example.net')],
+    }
+
+    class FakeResolver:
+        async def query_dns(self, _host: str, record_type: str):
+            records = [SimpleNamespace(data=SimpleNamespace(**{field: value})) for field, value in values[record_type]]
+            return SimpleNamespace(answer=records)
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', lambda **_kwargs: FakeResolver())
+
+    checker = hostchecker.Checker(['mixed.example.com'], nameservers=[])
+
+    resolved, hosts, addresses = await checker.check()
+
+    assert resolved == ['mixed.example.com:192.0.2.10,2001:db8::10']
+    assert hosts == ['mixed.example.com']
+    assert addresses == ['192.0.2.10', '2001:db8::10']
+    assert checker.evidence['mixed.example.com'] == hostchecker.HostEvidence(
+        ipv4=('192.0.2.10',),
+        ipv6=('2001:db8::10',),
+        cnames=('target.example.net',),
+    )
+
+
+@pytest.mark.parametrize(
+    'failure',
+    [
+        hostchecker.aiodns.error.DNSError(hostchecker.aiodns.error.ARES_ENOTFOUND, 'not found'),
+        hostchecker.aiodns.error.DNSError(hostchecker.aiodns.error.ARES_ENODATA, 'no data'),
+        RuntimeError('resolver failed'),
+        TimeoutError('timed out'),
+        None,
+    ],
+    ids=['nxdomain', 'nodata', 'resolver-error', 'timeout', 'empty-answer'],
+)
+@pytest.mark.asyncio
+async def test_check_excludes_candidates_without_usable_evidence(
+    monkeypatch: pytest.MonkeyPatch, failure: BaseException | None
+) -> None:
+    class FakeResolver:
+        async def query_dns(self, _host: str, _record_type: str):
+            if failure is not None:
+                raise failure
+            return SimpleNamespace(answer=[])
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', lambda **_kwargs: FakeResolver())
+
+    checker = hostchecker.Checker(['missing.example.com'], nameservers=[])
+
+    assert await checker.check() == ([], [], [])
+    assert checker.evidence == {}
+
+
+@pytest.mark.asyncio
+async def test_check_propagates_cancellation(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeResolver:
+        async def query_dns(self, _host: str, record_type: str):
+            if record_type == 'A':
+                raise asyncio.CancelledError
+            return SimpleNamespace(answer=[])
+
+    monkeypatch.setattr(hostchecker.aiodns, 'DNSResolver', lambda **_kwargs: FakeResolver())
+
+    checker = hostchecker.Checker(['cancelled.example.com'], nameservers=[])
+
+    with pytest.raises(asyncio.CancelledError):
+        await checker.check()

--- a/theHarvester/lib/hostchecker.py
+++ b/theHarvester/lib/hostchecker.py
@@ -7,7 +7,8 @@ Revised to use aiodns & asyncio on 2019-09-23
 from __future__ import annotations
 
 import asyncio
-import socket
+import ipaddress
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import aiodns
@@ -16,11 +17,31 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
+@dataclass(frozen=True)
+class HostEvidence:
+    ipv4: tuple[str, ...] = ()
+    ipv6: tuple[str, ...] = ()
+    cnames: tuple[str, ...] = ()
+
+    @property
+    def addresses(self) -> tuple[str, ...]:
+        return self.ipv4 + self.ipv6
+
+
 class Checker:
+    """Resolve hosts while preserving the legacy ``check()`` return tuple.
+
+    Typed A, AAAA, and CNAME values are available in ``evidence``. Existing
+    callers still receive resolved strings, retained hostnames, and IP
+    addresses from ``check()``; CNAME-only hosts use the existing plain-host
+    string form because there is no IP address to append.
+    """
+
     def __init__(self, hosts: list[str], nameservers: list[str]) -> None:
         self.hosts: list[str] = hosts
         self.realhosts: list[str] = []
         self.addresses: set[str] = set()
+        self.evidence: dict[str, HostEvidence] = {}
         self.nameservers: list[str] = nameservers
 
     # @staticmethod
@@ -36,18 +57,30 @@ class Checker:
     #         return f"{host}", tuple()
 
     @staticmethod
-    async def resolve_host(host: str, resolver: aiodns.DNSResolver) -> str:
-        try:
-            # TODO add check for ipv6 addrs as well
-            result = await resolver.getaddrinfo(host, socket.AF_INET)
-            addresses_list: list[str] = [r.addr[0] for r in result.nodes]
-            if addresses_list == [] or addresses_list is None or result is None:
-                return f'{host}:'
-            else:
-                addresses_str = ','.join(map(str, list(sorted(set(addresses_list)))))
-                return f'{host}:{addresses_str}'
-        except Exception:
-            return f'{host}:'
+    async def resolve_host(host: str, resolver: aiodns.DNSResolver) -> tuple[str, HostEvidence] | None:
+        record_types = ('A', 'AAAA', 'CNAME')
+        results = await asyncio.gather(
+            *(resolver.query_dns(host, record_type) for record_type in record_types),
+            return_exceptions=True,
+        )
+        values: dict[str, set[str]] = {record_type: set() for record_type in record_types}
+        for record_type, result in zip(record_types, results, strict=True):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            if isinstance(result, BaseException):
+                continue
+            for record in result.answer:
+                value = getattr(record.data, 'cname' if record_type == 'CNAME' else 'addr', None)
+                if value is None:
+                    continue
+                normalized = value.rstrip('.').lower() if record_type == 'CNAME' else str(ipaddress.ip_address(value))
+                values[record_type].add(normalized)
+        evidence = HostEvidence(
+            ipv4=tuple(sorted(values['A'])),
+            ipv6=tuple(sorted(values['AAAA'])),
+            cnames=tuple(sorted(values['CNAME'])),
+        )
+        return (host, evidence) if evidence.addresses or evidence.cnames else None
 
     # https://stackoverflow.com/questions/312443/how-do-i-split-a-list-into-equally-sized-chunks
     @staticmethod
@@ -56,9 +89,9 @@ class Checker:
         for i in range(0, len(lst), n):
             yield lst[i : i + n]
 
-    async def query_all(self, resolver: aiodns.DNSResolver, hosts: list[str]) -> list[str]:
+    async def query_all(self, resolver: aiodns.DNSResolver, hosts: list[str]) -> list[tuple[str, HostEvidence] | None]:
         # TODO chunk list into 50 pieces regardless of IPs and subnets
-        results: list[str] = await asyncio.gather(*[asyncio.create_task(self.resolve_host(host, resolver)) for host in hosts])
+        results = await asyncio.gather(*[asyncio.create_task(self.resolve_host(host, resolver)) for host in hosts])
         return results
 
     async def check(self) -> tuple[list[str], list[str], list[str]]:
@@ -72,12 +105,17 @@ class Checker:
         for chunk in self.chunks(self.hosts, 50):
             # TODO split this to get IPs added total ips
             results = await self.query_all(resolver, chunk)
-            all_results.update(results)
-            for pair in results:
-                host, addresses = pair.split(':')
+            for result in results:
+                if result is None:
+                    continue
+                host, evidence = result
+                self.evidence[host] = evidence
+                addresses = ','.join(evidence.addresses)
+                legacy_result = f'{host}:{addresses}' if addresses else host
+                all_results.add(legacy_result)
                 self.realhosts.append(host)
                 # address may be a list of ips; filter out empties
-                self.addresses.update({addr for addr in addresses.split(',') if addr})
+                self.addresses.update(evidence.addresses)
                 # address may be a list of ips
                 # and do a set comprehension to remove duplicates
         self.realhosts.sort()


### PR DESCRIPTION
## Summary

- retain typed A, AAAA, and CNAME DNS evidence
- preserve the legacy `Checker.check()` output contract
- cover resolver success, failure, deduplication, and ordering behavior

## Validation

`uv run pytest tests/lib/test_hostchecker.py`

Result: 10 passed.

