### PR TITLE
Support JSON request bodies in AsyncFetcher

### DIFF
--- a/tests/discovery/test_criminalip.py
+++ b/tests/discovery/test_criminalip.py
@@ -58,6 +58,8 @@ async def test_do_search_uses_v2_report_endpoint(monkeypatch) -> None:
 
     async def fake_post_fetch(url, **kwargs):
         assert url == 'https://api.criminalip.io/v1/domain/scan'
+        assert kwargs['json_body'] == {'query': 'example.com'}
+        assert 'data' not in kwargs
         return {'status': 200, 'data': {'scan_id': 12345}}
 
     async def fake_fetch_all(urls, **kwargs):

--- a/tests/discovery/test_dymosearch.py
+++ b/tests/discovery/test_dymosearch.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from theHarvester.discovery import dymosearch
@@ -37,13 +39,14 @@ class TestDymoSearch:
     @pytest.mark.asyncio
     async def test_process_extracts_canonical_and_suggestion(self, monkeypatch):
         _patch_dymo_key(monkeypatch, 'token-xyz')
-        captured = {}
+        captured: dict[str, Any] = {}
 
-        async def fake_post_fetch(url, headers=None, data='', params='', json=False, proxy=False):
+        async def fake_post_fetch(url: str, **kwargs: Any) -> dict[str, Any]:
             captured['url'] = url
-            captured['headers'] = headers
-            captured['data'] = data
-            captured['proxy'] = proxy
+            captured['headers'] = kwargs.get('headers')
+            captured['data'] = kwargs.get('data', '')
+            captured['json_body'] = kwargs.get('json_body')
+            captured['proxy'] = kwargs.get('proxy', False)
             return {
                 'domain': {
                     'valid': True,
@@ -68,7 +71,8 @@ class TestDymoSearch:
 
         assert captured['url'] == dymosearch.SearchDymo.VERIFY_URL
         assert captured['proxy'] is True
-        assert captured['data'] == {'domain': 'exemple.com', 'url': 'https://exemple.com'}
+        assert captured['data'] == ''
+        assert captured['json_body'] == {'domain': 'exemple.com', 'url': 'https://exemple.com'}
         assert captured['headers']['Authorization'] == 'Bearer token-xyz'
 
         hosts = await search.get_hostnames()
@@ -82,7 +86,7 @@ class TestDymoSearch:
     async def test_process_handles_empty_payload(self, monkeypatch):
         _patch_dymo_key(monkeypatch, 'token')
 
-        async def fake_post_fetch(url, headers=None, data='', params='', json=False, proxy=False):
+        async def fake_post_fetch(_url: str, **_kwargs: Any) -> dict[str, Any]:
             return {}
 
         import theHarvester.lib.core as core_module
@@ -98,7 +102,7 @@ class TestDymoSearch:
     async def test_process_ignores_unrelated_suggestion(self, monkeypatch):
         _patch_dymo_key(monkeypatch, 'token')
 
-        async def fake_post_fetch(url, headers=None, data='', params='', json=False, proxy=False):
+        async def fake_post_fetch(_url: str, **_kwargs: Any) -> dict[str, Any]:
             return {
                 'domain': {
                     'valid': True,
@@ -120,7 +124,7 @@ class TestDymoSearch:
     async def test_process_handles_non_dict_response(self, monkeypatch):
         _patch_dymo_key(monkeypatch, 'token')
 
-        async def fake_post_fetch(url, headers=None, data='', params='', json=False, proxy=False):
+        async def fake_post_fetch(_url: str, **_kwargs: Any) -> str:
             return '<html>error</html>'
 
         import theHarvester.lib.core as core_module

--- a/tests/discovery/test_pentesttools.py
+++ b/tests/discovery/test_pentesttools.py
@@ -1,0 +1,62 @@
+from typing import Any
+
+import pytest
+
+from theHarvester.discovery import pentesttools
+
+
+@pytest.mark.asyncio
+async def test_do_search_sends_json_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pentesttools.Core, 'pentest_tools_key', lambda: 'test-key')
+    captured: dict[str, Any] = {}
+
+    async def fake_post_fetch(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return '{"op_status": "success", "scan_id": 123}'
+
+    async def fake_poll(_scan_id: int) -> None:
+        return None
+
+    monkeypatch.setattr(pentesttools.AsyncFetcher, 'post_fetch', fake_post_fetch)
+
+    search = pentesttools.SearchPentestTools('example.com')
+    monkeypatch.setattr(search, 'poll', fake_poll)
+    await search.do_search()
+
+    assert captured['json_body'] == {
+        'op': 'start_scan',
+        'tool_id': 20,
+        'tool_params': {
+            'target': 'example.com',
+            'web_details': 'off',
+            'do_smart_search': 'off',
+        },
+    }
+    assert 'data' not in captured
+
+
+@pytest.mark.asyncio
+async def test_poll_sends_json_bodies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pentesttools.Core, 'pentest_tools_key', lambda: 'test-key')
+    calls: list[dict[str, Any]] = []
+
+    async def fake_sleep(_seconds: int) -> None:
+        return None
+
+    async def fake_post_fetch(**kwargs: Any) -> str:
+        calls.append(kwargs)
+        if len(calls) == 1:
+            return '{"op_status": "success", "scan_status": "finished"}'
+        return '{"op_status": "success", "scan_output": {"output_json": [{"output_data": []}]}}'
+
+    monkeypatch.setattr(pentesttools.asyncio, 'sleep', fake_sleep)
+    monkeypatch.setattr(pentesttools.AsyncFetcher, 'post_fetch', fake_post_fetch)
+
+    search = pentesttools.SearchPentestTools('example.com')
+    await search.poll(123)
+
+    assert [call['json_body'] for call in calls] == [
+        {'op': 'get_scan_status', 'scan_id': 123},
+        {'op': 'get_output', 'scan_id': 123, 'output_format': 'json'},
+    ]
+    assert all('data' not in call for call in calls)

--- a/tests/discovery/test_rocketreach.py
+++ b/tests/discovery/test_rocketreach.py
@@ -1,5 +1,6 @@
 import sys
 import types
+from typing import Any
 
 import pytest
 
@@ -38,8 +39,17 @@ async def test_do_search_uses_people_data_endpoint_and_start_pagination(monkeypa
 
     calls = []
 
-    async def fake_post_fetch(url, headers=None, data=None, json=False, **kwargs):
-        calls.append((url, headers, data, json, kwargs))
+    async def fake_post_fetch(url: str, **kwargs: Any) -> dict[str, Any]:
+        calls.append(
+            (
+                url,
+                kwargs.get('headers'),
+                kwargs.get('data'),
+                kwargs.get('json', False),
+                kwargs.get('json_body'),
+                kwargs,
+            )
+        )
         if len(calls) == 1:
             first_page_profiles = []
             for index in range(100):
@@ -73,16 +83,19 @@ async def test_do_search_uses_people_data_endpoint_and_start_pagination(monkeypa
     await search.process()
 
     assert len(calls) == 2
-    first_url, first_headers, first_data, first_json, _ = calls[0]
-    second_url, _, second_data, _, _ = calls[1]
+    first_url, first_headers, first_data, first_json, first_json_body, _ = calls[0]
+    second_url, _, second_data, _, second_json_body, _ = calls[1]
 
     assert first_url == 'https://api.rocketreach.co/api/v2/person/search'
     assert second_url == 'https://api.rocketreach.co/api/v2/person/search'
+    assert isinstance(first_headers, dict)
     assert first_headers['Api-Key'] == 'test-key'
     assert first_headers['User-Agent'] == 'test-agent'
     assert first_json is True
-    assert first_data == {'query': {'current_employer_domain': ['example.com']}, 'start': 0, 'page_size': 100}
-    assert second_data == {'query': {'current_employer_domain': ['example.com']}, 'start': 100, 'page_size': 50}
+    assert first_data is None
+    assert first_json_body == {'query': {'current_employer_domain': ['example.com']}, 'start': 0, 'page_size': 100}
+    assert second_data is None
+    assert second_json_body == {'query': {'current_employer_domain': ['example.com']}, 'start': 100, 'page_size': 50}
 
     links = await search.get_links()
     emails = await search.get_emails()

--- a/tests/discovery/test_windvane.py
+++ b/tests/discovery/test_windvane.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+import pytest
+
+from theHarvester.discovery import windvane
+
+
+@pytest.mark.asyncio
+async def test_authenticated_search_sends_json_bodies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(windvane.Core, 'windvane_key', lambda: 'test-key')
+    monkeypatch.setattr(windvane.Core, 'get_user_agent', lambda: 'test-agent')
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def fake_post_fetch(url: str, **kwargs: Any) -> str:
+        calls.append((url, kwargs))
+        return '{"code": 1}'
+
+    monkeypatch.setattr(windvane.AsyncFetcher, 'post_fetch', fake_post_fetch)
+
+    search = windvane.SearchWindvane('example.com')
+    await search.do_search()
+
+    assert [url.rsplit('/', 1)[-1] for url, _ in calls] == ['ListSubDomain', 'ListDNS', 'ListEmail']
+    assert [kwargs['json_body'] for _, kwargs in calls] == [
+        {'domain': 'example.com', 'page_request': {'page': 1, 'count': 30}},
+        {'domain': 'example.com', 'page_request': {'page': 1, 'count': 30}},
+        {'email': 'example.com', 'page_request': {'page': 1, 'count': 50}},
+    ]
+    assert all('data' not in kwargs for _, kwargs in calls)
+
+
+@pytest.mark.asyncio
+async def test_limited_search_sends_json_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(windvane.Core, 'windvane_key', lambda: None)
+    monkeypatch.setattr(windvane.Core, 'get_user_agent', lambda: 'test-agent')
+    captured: dict[str, Any] = {}
+
+    async def fake_post_fetch(url: str, **kwargs: Any) -> str:
+        captured.update(kwargs)
+        return '{"code": 0, "data": {"list": []}}'
+
+    monkeypatch.setattr(windvane.AsyncFetcher, 'post_fetch', fake_post_fetch)
+
+    search = windvane.SearchWindvane('example.com')
+    await search.do_search()
+
+    assert captured['json_body'] == {
+        'domain': 'example.com',
+        'page_request': {'page': 1, 'count': 10},
+    }
+    assert 'data' not in captured

--- a/tests/lib/test_core.py
+++ b/tests/lib/test_core.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import pytest
 import yaml
+from aiohttp import web
 
 import theHarvester.lib.core as core_module
 from theHarvester.lib.core import CONFIG_DIRS, DATA_DIR, AsyncFetcher, Core
@@ -252,7 +253,88 @@ async def test_post_fetch_decodes_string_payload_and_posts_params(monkeypatch) -
 
 
 @pytest.mark.asyncio
-async def test_post_fetch_proxy_branch_uses_get_with_http_proxy(monkeypatch) -> None:
+async def test_post_fetch_sends_json_body_without_decoding_response(
+    monkeypatch: pytest.MonkeyPatch, unused_tcp_port: int
+) -> None:
+    received: dict[str, Any] = {}
+
+    async def capture_json(request: web.Request) -> web.Response:
+        received['method'] = request.method
+        received['content_type'] = request.content_type
+        received['json'] = await request.json()
+        return web.Response(text='accepted')
+
+    app = web.Application()
+    app.router.add_post('/', capture_json)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, '127.0.0.1', unused_tcp_port)
+    await site.start()
+    monkeypatch.setattr(core_module.asyncio, 'sleep', fake_sleep)
+
+    try:
+        result = await AsyncFetcher.post_fetch(
+            f'http://127.0.0.1:{unused_tcp_port}/',
+            json_body={'query': 'example'},
+        )
+    finally:
+        await runner.cleanup()
+
+    assert result == 'accepted'
+    assert received == {
+        'method': 'POST',
+        'content_type': 'application/json',
+        'json': {'query': 'example'},
+    }
+
+
+@pytest.mark.asyncio
+async def test_post_fetch_sends_raw_text_body(monkeypatch: pytest.MonkeyPatch, unused_tcp_port: int) -> None:
+    received: dict[str, str] = {}
+
+    async def capture_text(request: web.Request) -> web.Response:
+        received['method'] = request.method
+        received['body'] = await request.text()
+        return web.Response(text='accepted')
+
+    app = web.Application()
+    app.router.add_post('/', capture_text)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, '127.0.0.1', unused_tcp_port)
+    await site.start()
+    monkeypatch.setattr(core_module.asyncio, 'sleep', fake_sleep)
+
+    try:
+        result = await AsyncFetcher.post_fetch(
+            f'http://127.0.0.1:{unused_tcp_port}/',
+            data='plain text',
+        )
+    finally:
+        await runner.cleanup()
+
+    assert result == 'accepted'
+    assert received == {'method': 'POST', 'body': 'plain text'}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('post_kwargs', 'expected_request_kwargs', 'expected_result'),
+    [
+        (
+            {'json_body': {'query': 'example'}, 'json': True},
+            {'proxy': 'http://proxy.local:8080', 'json': {'query': 'example'}},
+            {'ok': True},
+        ),
+        ({}, {'proxy': 'http://proxy.local:8080', 'data': ''}, 'response-text'),
+    ],
+)
+async def test_post_fetch_proxy_preserves_post(
+    monkeypatch: pytest.MonkeyPatch,
+    post_kwargs: dict[str, Any],
+    expected_request_kwargs: dict[str, Any],
+    expected_result: Any,
+) -> None:
     reset_dummy_sessions()
     created_connectors = []
     monkeypatch.setattr(core_module.aiohttp, 'ClientSession', DummySession)
@@ -267,12 +349,16 @@ async def test_post_fetch_proxy_branch_uses_get_with_http_proxy(monkeypatch) -> 
 
     monkeypatch.setattr(AsyncFetcher, '_create_connector', fake_create_connector)
 
-    result = await AsyncFetcher.post_fetch('https://example.com/resource', proxy=True)
+    result = await AsyncFetcher.post_fetch('https://example.com/resource', proxy=True, **post_kwargs)
 
-    assert result == 'response-text'
+    assert result == expected_result
     assert created_connectors == [('http://proxy.local:8080', 'http', 'ssl-context')]
     session = DummySession.instances[0]
     assert session.connector == 'connector'
     assert session.requests == [
-        ('GET', 'https://example.com/resource', {'proxy': 'http://proxy.local:8080'})
+        (
+            'POST',
+            'https://example.com/resource',
+            expected_request_kwargs,
+        )
     ]

--- a/theHarvester/discovery/criminalip.py
+++ b/theHarvester/discovery/criminalip.py
@@ -87,14 +87,14 @@ class SearchCriminalIP:
         # https://www.criminalip.io/developer/api/get-domain-status-id
         # https://www.criminalip.io/developer/api/get-v2-domain-report-id
         url = 'https://api.criminalip.io/v1/domain/scan'
-        data = f'{{"query": "{self.word}"}}'
+        data = {'query': self.word}
         # print(f'Current key: {self.key}')
         user_agent = Core.get_user_agent()
         response = await AsyncFetcher.post_fetch(
             url,
             json=True,
             headers={'User-Agent': user_agent, 'x-api-key': f'{self.key}'},
-            data=data,
+            json_body=data,
             proxy=self.proxy,
         )
         # print(f'My response: {response}')

--- a/theHarvester/discovery/dymosearch.py
+++ b/theHarvester/discovery/dymosearch.py
@@ -43,7 +43,7 @@ class SearchDymo:
         response = await AsyncFetcher.post_fetch(
             self.VERIFY_URL,
             headers=self._headers(),
-            data=payload,
+            json_body=payload,
             json=True,
             proxy=self.proxy,
         )

--- a/theHarvester/discovery/pentesttools.py
+++ b/theHarvester/discovery/pentesttools.py
@@ -22,7 +22,7 @@ class SearchPentestTools:
             await asyncio.sleep(3)
             # Get the status of our scan
             scan_status_data = {'op': 'get_scan_status', 'scan_id': scan_id}
-            responses = await AsyncFetcher.post_fetch(url=self.api, data=ujson.dumps(scan_status_data), proxy=self.proxy)
+            responses = await AsyncFetcher.post_fetch(url=self.api, json_body=scan_status_data, proxy=self.proxy)
             res_json = ujson.loads(responses.strip())
             if res_json['op_status'] == 'success':
                 if res_json['scan_status'] != 'waiting' and res_json['scan_status'] != 'running':
@@ -31,7 +31,7 @@ class SearchPentestTools:
                         'scan_id': scan_id,
                         'output_format': 'json',
                     }
-                    responses = await AsyncFetcher.post_fetch(url=self.api, data=ujson.dumps(getoutput_data), proxy=self.proxy)
+                    responses = await AsyncFetcher.post_fetch(url=self.api, json_body=getoutput_data, proxy=self.proxy)
 
                     res_json = ujson.loads(responses.strip('\n'))
                     self.total_results = await self.parse_json(res_json)
@@ -63,7 +63,7 @@ class SearchPentestTools:
                 'do_smart_search': 'off',
             },
         }
-        responses = await AsyncFetcher.post_fetch(url=self.api, data=ujson.dumps(subdomain_payload), proxy=self.proxy)
+        responses = await AsyncFetcher.post_fetch(url=self.api, json_body=subdomain_payload, proxy=self.proxy)
         res_json = ujson.loads(responses.strip())
         if res_json['op_status'] == 'success':
             scan_id = res_json['scan_id']

--- a/theHarvester/discovery/rocketreach.py
+++ b/theHarvester/discovery/rocketreach.py
@@ -38,7 +38,7 @@ class SearchRocketReach:
                     'start': start,
                     'page_size': page_size,
                 }
-                result = await AsyncFetcher.post_fetch(self.baseurl, headers=headers, data=data, json=True)
+                result = await AsyncFetcher.post_fetch(self.baseurl, headers=headers, json_body=data, json=True)
                 if not isinstance(result, dict):
                     break
 

--- a/theHarvester/discovery/windvane.py
+++ b/theHarvester/discovery/windvane.py
@@ -92,7 +92,7 @@ class SearchWindvane:
                 data = {'domain': self.word, 'page_request': {'page': page, 'count': 30}}
 
                 try:
-                    response = await AsyncFetcher.post_fetch(url, headers=headers, data=json.dumps(data), proxy=self.proxy)
+                    response = await AsyncFetcher.post_fetch(url, headers=headers, json_body=data, proxy=self.proxy)
                     if response:
                         response_data = self._safe_parse_json(response)
 
@@ -132,7 +132,7 @@ class SearchWindvane:
                 data = {'domain': self.word, 'page_request': {'page': page, 'count': 30}}
 
                 try:
-                    response = await AsyncFetcher.post_fetch(url, headers=headers, data=json.dumps(data), proxy=self.proxy)
+                    response = await AsyncFetcher.post_fetch(url, headers=headers, json_body=data, proxy=self.proxy)
                     if response:
                         response_data = self._safe_parse_json(response)
 
@@ -174,7 +174,7 @@ class SearchWindvane:
             data = {'email': self.word, 'page_request': {'page': 1, 'count': 50}}
 
             try:
-                response = await AsyncFetcher.post_fetch(url, headers=headers, data=json.dumps(data), proxy=self.proxy)
+                response = await AsyncFetcher.post_fetch(url, headers=headers, json_body=data, proxy=self.proxy)
                 if response:
                     response_data = self._safe_parse_json(response)
 
@@ -215,7 +215,7 @@ class SearchWindvane:
             }
 
             try:
-                response = await AsyncFetcher.post_fetch(url, headers=headers, data=json.dumps(data), proxy=self.proxy)
+                response = await AsyncFetcher.post_fetch(url, headers=headers, json_body=data, proxy=self.proxy)
                 if response:
                     response_data = self._safe_parse_json(response)
 

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -427,7 +427,12 @@ class AsyncFetcher:
 
     @staticmethod
     def _normalize_data(data: str | dict[str, Any]) -> str | dict[str, Any]:
-        return json_loader.loads(data) if isinstance(data, str) else data
+        if not isinstance(data, str):
+            return data
+        try:
+            return json_loader.loads(data)
+        except ValueError:
+            return data
 
     @classmethod
     def _resolve_proxy(cls, proxy: str | bool | None) -> tuple[str | None, str | None]:
@@ -466,7 +471,7 @@ class AsyncFetcher:
         method: str,
         url: str,
         *,
-        json: bool = False,
+        response_json: bool = False,
         delay: int = 5,
         request_timeout: int | None = None,
         **request_kwargs: Any,
@@ -474,10 +479,10 @@ class AsyncFetcher:
         if request_timeout:
             async with asyncio.timeout(request_timeout):
                 async with session.request(method.upper(), url, **request_kwargs) as response:
-                    return await cls._read_response(response, json=json, delay=delay)
+                    return await cls._read_response(response, json=response_json, delay=delay)
 
         async with session.request(method.upper(), url, **request_kwargs) as response:
-            return await cls._read_response(response, json=json, delay=delay)
+            return await cls._read_response(response, json=response_json, delay=delay)
 
     @staticmethod
     def _get_random_proxy(proxy_dict: dict) -> tuple[str | None, str | None]:
@@ -520,46 +525,39 @@ class AsyncFetcher:
         params: Sized = '',
         json: bool = False,
         proxy: bool = False,
+        json_body: dict[str, Any] | None = None,
     ):
         headers = cls._default_headers(headers)
         timeout = cls._request_timeout(720)
         # By default, timeout is 5 minutes, changed to 12-minutes
         # results are well worth the wait
         try:
+            request_kwargs: dict[str, Any] = {'json': json_body} if json_body is not None else {'data': cls._normalize_data(data)}
             if proxy:
                 proxy_url, proxy_type = cls._resolve_proxy(proxy)
                 sslcontext = cls._ssl_context()
-
                 if params != '':
-                    async with await cls._build_session(headers, timeout, proxy_url, proxy_type, sslcontext) as session:
-                        return await cls._request(
-                            session,
-                            'GET',
-                            url,
-                            params=params,
-                            proxy=proxy_url if proxy_type == 'http' else None,
-                            json=json,
-                            delay=5,
-                        )
-                else:
-                    async with await cls._build_session(headers, timeout, proxy_url, proxy_type, sslcontext) as session:
-                        return await cls._request(
-                            session,
-                            'GET',
-                            url,
-                            proxy=proxy_url if proxy_type == 'http' else None,
-                            json=json,
-                            delay=5,
-                        )
+                    request_kwargs['params'] = params
+                if proxy_type == 'http':
+                    request_kwargs['proxy'] = proxy_url
+                async with await cls._build_session(headers, timeout, proxy_url, proxy_type, sslcontext) as session:
+                    return await cls._request(
+                        session,
+                        'POST',
+                        url,
+                        response_json=json,
+                        delay=5,
+                        **request_kwargs,
+                    )
             elif params == '':
                 async with await cls._build_session(headers, timeout) as session:
                     return await cls._request(
                         session,
                         'POST',
                         url,
-                        data=cls._normalize_data(data),
-                        json=json,
+                        response_json=json,
                         delay=3,
+                        **request_kwargs,
                     )
             else:
                 async with await cls._build_session(headers, timeout) as session:
@@ -567,11 +565,11 @@ class AsyncFetcher:
                         session,
                         'POST',
                         url,
-                        data=cls._normalize_data(data),
                         ssl=cls._ssl_context(),
                         params=params,
-                        json=json,
+                        response_json=json,
                         delay=3,
+                        **request_kwargs,
                     )
         except (aiohttp.ClientError, TimeoutError, OSError, ssl.SSLError, UnicodeDecodeError, ValueError):
             return ''
@@ -627,7 +625,7 @@ class AsyncFetcher:
                     session,
                     method,
                     url,
-                    json=json,
+                    response_json=json,
                     delay=5,
                     request_timeout=request_timeout,
                     **request_kwargs,


### PR DESCRIPTION
## Summary

- add an explicit `json_body` request path to `AsyncFetcher.post_fetch`
- keep response JSON decoding separate from request encoding
- migrate JSON POST callers to the shared transport
- preserve proxy and form-body behavior

## Validation

`uv run pytest tests/lib/test_core.py tests/discovery/test_criminalip.py tests/discovery/test_dymosearch.py tests/discovery/test_pentesttools.py tests/discovery/test_rocketreach.py tests/discovery/test_windvane.py`

Result: 38 passed.

