### PR TITLE
Exhaust current Common Crawl indexes

### DIFF
--- a/tests/discovery/test_commoncrawl.py
+++ b/tests/discovery/test_commoncrawl.py
@@ -1,0 +1,135 @@
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from theHarvester.discovery import commoncrawl
+
+
+@pytest.mark.asyncio
+async def test_process_exhausts_current_catalog_index_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    catalog = [
+        {
+            'id': 'CC-MAIN-2026-30',
+            'cdx-api': 'https://index.commoncrawl.org/CC-MAIN-2026-30-index',
+            'to': '2026-07-12T00:00:00',
+        }
+    ]
+
+    async def fake_fetch_all(urls: list[str], **kwargs: object) -> list[object]:
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            assert kwargs['json'] is True
+            return [catalog]
+
+        responses: list[str] = []
+        for url in urls:
+            query = parse_qs(urlsplit(url).query)
+            if query.get('showNumPages') == ['true']:
+                responses.append('{"pages": 2, "pageSize": 5, "blocks": 6}')
+            elif query['url'] == ['*.example.com'] and query['page'] == ['0']:
+                responses.append('{"url":"https://api.example.com/v1"}')
+            elif query['url'] == ['*.example.com'] and query['page'] == ['1']:
+                responses.append('{"url":"https://mail.example.com/inbox"}')
+            elif query['url'] == ['example.com/*'] and query['page'] == ['0']:
+                responses.append('{"url":"https://example.com/"}')
+            else:
+                responses.append('{"url":"https://www.example.com/about"}')
+        return responses
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = commoncrawl.SearchCommoncrawl('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == {
+        'api.example.com',
+        'example.com',
+        'mail.example.com',
+        'www.example.com',
+    }
+
+
+@pytest.mark.asyncio
+async def test_process_uses_unique_indexes_from_latest_catalog_year_window_and_scopes_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current_endpoint = 'https://index.commoncrawl.org/CC-MAIN-2026-30-index'
+    recent_endpoint = 'https://index.commoncrawl.org/CC-MAIN-2025-35-index'
+    old_endpoint = 'https://index.commoncrawl.org/CC-MAIN-2024-30-index'
+    catalog = [
+        {'id': 'CC-MAIN-2026-30', 'cdx-api': current_endpoint, 'to': '2026-07-12T00:00:00'},
+        {'id': 'CC-MAIN-2025-35', 'cdx-api': recent_endpoint, 'to': '2025-08-28T00:00:00'},
+        {'id': 'CC-MAIN-2026-30-copy', 'cdx-api': current_endpoint, 'to': '2026-07-12T00:00:00'},
+        {'id': 'CC-MAIN-2024-30', 'cdx-api': old_endpoint, 'to': '2024-07-22T00:00:00'},
+    ]
+    requested_urls: list[str] = []
+
+    async def fake_fetch_all(urls: list[str], **kwargs: object) -> list[object]:
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            return [catalog]
+
+        requested_urls.extend(urls)
+        responses: list[str] = []
+        for url in urls:
+            parsed = urlsplit(url)
+            query = parse_qs(parsed.query)
+            if query.get('showNumPages') == ['true']:
+                responses.append('{"pages": 1, "pageSize": 5, "blocks": 1}')
+            elif parsed.path.endswith('CC-MAIN-2026-30-index') and query['url'] == ['*.example.com']:
+                responses.append('{"url":"https://API.Example.COM./v1"}')
+            elif parsed.path.endswith('CC-MAIN-2026-30-index'):
+                responses.append('{"url":"https://example.com/"}')
+            elif query['url'] == ['*.example.com']:
+                responses.append('{"url":"https://api.example.com/duplicate"}\n{"url":"https://dev.example.com/"}')
+            else:
+                responses.append('{"url":"https://example.com.attacker.net/"}\n{"url":"https://notexample.com/"}')
+        return responses
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = commoncrawl.SearchCommoncrawl('Example.COM.')
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com', 'dev.example.com', 'example.com'}
+    assert sum(current_endpoint in url for url in requested_urls) == 4
+    assert sum(recent_endpoint in url for url in requested_urls) == 4
+    assert all(old_endpoint not in url for url in requested_urls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('broken_payload', ['not-json', ''])
+async def test_process_reports_failed_or_malformed_index_without_discarding_other_results(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], broken_payload: str
+) -> None:
+    broken_endpoint = 'https://index.commoncrawl.org/CC-MAIN-2026-30-index'
+    good_endpoint = 'https://index.commoncrawl.org/CC-MAIN-2026-26-index'
+    catalog = [
+        {'id': 'CC-MAIN-BROKEN', 'cdx-api': 'https://index.commoncrawl.org/broken-index'},
+        {'id': 'CC-MAIN-2026-30', 'cdx-api': broken_endpoint, 'to': '2026-07-12T00:00:00'},
+        {'id': 'CC-MAIN-2026-26', 'cdx-api': good_endpoint, 'to': '2026-06-18T00:00:00'},
+    ]
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            return [catalog]
+
+        responses: list[str] = []
+        for url in urls:
+            parsed = urlsplit(url)
+            query = parse_qs(parsed.query)
+            if query.get('showNumPages') == ['true']:
+                responses.append('{"pages": 1, "pageSize": 5, "blocks": 1}')
+            elif parsed.path.endswith('CC-MAIN-2026-30-index'):
+                responses.append(broken_payload)
+            else:
+                responses.append('{"url":"https://survivor.example.com/"}')
+        return responses
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    search = commoncrawl.SearchCommoncrawl('example.com')
+    await search.process()
+
+    assert await search.get_hostnames() == {'survivor.example.com'}
+    output = capsys.readouterr().out
+    assert 'CC-MAIN-BROKEN' in output
+    assert 'CC-MAIN-2026-30' in output

--- a/tests/discovery/test_commoncrawl.py
+++ b/tests/discovery/test_commoncrawl.py
@@ -1,3 +1,4 @@
+import logging
 from urllib.parse import parse_qs, urlsplit
 
 import pytest
@@ -98,7 +99,7 @@ async def test_process_uses_unique_indexes_from_latest_catalog_year_window_and_s
 @pytest.mark.asyncio
 @pytest.mark.parametrize('broken_payload', ['not-json', ''])
 async def test_process_reports_failed_or_malformed_index_without_discarding_other_results(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], broken_payload: str
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, broken_payload: str
 ) -> None:
     broken_endpoint = 'https://index.commoncrawl.org/CC-MAIN-2026-30-index'
     good_endpoint = 'https://index.commoncrawl.org/CC-MAIN-2026-26-index'
@@ -127,17 +128,17 @@ async def test_process_reports_failed_or_malformed_index_without_discarding_othe
     monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
 
     search = commoncrawl.SearchCommoncrawl('example.com')
-    await search.process()
+    with caplog.at_level(logging.WARNING, logger=commoncrawl.__name__):
+        await search.process()
 
     assert await search.get_hostnames() == {'survivor.example.com'}
-    output = capsys.readouterr().out
-    assert 'CC-MAIN-BROKEN' in output
-    assert 'CC-MAIN-2026-30' in output
+    assert 'CC-MAIN-BROKEN' in caplog.text
+    assert 'CC-MAIN-2026-30' in caplog.text
 
 
 @pytest.mark.asyncio
 async def test_process_reports_non_json_upstream_response(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     catalog = [
         {
@@ -156,10 +157,13 @@ async def test_process_reports_non_json_upstream_response(
 
     monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
 
-    with pytest.raises(RuntimeError, match='all Common Crawl queries failed'):
+    with (
+        caplog.at_level(logging.WARNING, logger=commoncrawl.__name__),
+        pytest.raises(RuntimeError, match='all Common Crawl queries failed'),
+    ):
         await commoncrawl.SearchCommoncrawl('example.com').process()
 
-    assert 'unexpected non-JSON response' in capsys.readouterr().out
+    assert 'unexpected non-JSON response' in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/discovery/test_commoncrawl.py
+++ b/tests/discovery/test_commoncrawl.py
@@ -133,3 +133,58 @@ async def test_process_reports_failed_or_malformed_index_without_discarding_othe
     output = capsys.readouterr().out
     assert 'CC-MAIN-BROKEN' in output
     assert 'CC-MAIN-2026-30' in output
+
+
+@pytest.mark.asyncio
+async def test_process_reports_non_json_upstream_response(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    catalog = [
+        {
+            'id': 'CC-MAIN-2026-30',
+            'cdx-api': 'https://index.commoncrawl.org/CC-MAIN-2026-30-index',
+            'to': '2026-07-12T00:00:00',
+        }
+    ]
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            return [catalog]
+        if 'showNumPages=true' in urls[0]:
+            return ['{"pages": 1, "pageSize": 5, "blocks": 1}']
+        return ['<html><h1>504 Gateway Time-out</h1></html>']
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+
+    with pytest.raises(RuntimeError, match='all Common Crawl queries failed'):
+        await commoncrawl.SearchCommoncrawl('example.com').process()
+
+    assert 'unexpected non-JSON response' in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_process_keeps_results_when_another_query_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    catalog = [
+        {
+            'id': 'CC-MAIN-2026-30',
+            'cdx-api': 'https://index.commoncrawl.org/CC-MAIN-2026-30-index',
+            'to': '2026-07-12T00:00:00',
+        }
+    ]
+
+    async def fake_fetch_all(urls: list[str], **_kwargs: object) -> list[object]:
+        if urls == ['https://index.commoncrawl.org/collinfo.json']:
+            return [catalog]
+        query = parse_qs(urlsplit(urls[0]).query)
+        if query.get('showNumPages') == ['true']:
+            return ['{"pages": 1, "pageSize": 5, "blocks": 1}']
+        if query['url'] == ['*.example.com']:
+            return ['{"url":"https://api.example.com/v1"}']
+        return ['<html><h1>504 Gateway Time-out</h1></html>']
+
+    monkeypatch.setattr(commoncrawl.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = commoncrawl.SearchCommoncrawl('example.com')
+
+    await search.process()
+
+    assert await search.get_hostnames() == {'api.example.com'}

--- a/theHarvester/discovery/commoncrawl.py
+++ b/theHarvester/discovery/commoncrawl.py
@@ -1,6 +1,7 @@
 import json as _stdlib_json
-import re
+from datetime import datetime, timedelta
 from types import ModuleType
+from urllib.parse import urlencode, urlsplit
 
 from theHarvester.lib.core import AsyncFetcher, Core
 
@@ -16,11 +17,14 @@ except Exception:
 
 
 class SearchCommoncrawl:
-    """Class uses Common Crawl index API to gather subdomains from archived web data"""
+    """Gather subdomains from every crawl ending within one year of the newest catalog entry."""
+
+    INDEX_LOOKBACK = timedelta(days=365)
+    PAGE_SIZE = 5
 
     def __init__(self, word) -> None:
-        self.word = word
-        self.totalhosts: set = set()
+        self.word = word.lower().rstrip('.')
+        self.totalhosts: set[str] = set()
         self.proxy = False
         self.hostname = 'https://index.commoncrawl.org'
 
@@ -35,8 +39,8 @@ class SearchCommoncrawl:
             if line.strip():
                 try:
                     results.append(json.loads(line))
-                except Exception:
-                    continue
+                except Exception as error:
+                    raise ValueError('malformed JSON line') from error
         return results
 
     def _extract_domain_from_url(self, url: str) -> str:
@@ -44,75 +48,78 @@ class SearchCommoncrawl:
         if not url:
             return ''
 
-        # Remove protocol
-        url = re.sub(r'^https?://', '', url)
+        parsed = urlsplit(url if '://' in url else f'//{url}')
+        return (parsed.hostname or '').lower().rstrip('.')
 
-        # Extract domain part (before first /)
-        domain = url.split('/')[0]
+    @classmethod
+    def _select_indexes(cls, catalog: list[object]) -> list[dict]:
+        dated_indexes: list[tuple[datetime, dict]] = []
+        for entry in catalog:
+            if not isinstance(entry, dict):
+                print('Common Crawl API error for index unknown: invalid catalog entry')
+                continue
+            index_id = entry.get('id', 'unknown')
+            if not isinstance(entry.get('cdx-api'), str):
+                print(f'Common Crawl API error for index {index_id}: invalid catalog entry')
+                continue
+            try:
+                timestamp = datetime.fromisoformat(str(entry['to'])).replace(tzinfo=None)
+            except (KeyError, ValueError):
+                print(f'Common Crawl API error for index {index_id}: invalid catalog entry')
+                continue
+            dated_indexes.append((timestamp, entry))
 
-        # Remove port if present
-        domain = domain.split(':')[0]
+        if not dated_indexes:
+            return []
 
-        return domain.lower()
+        cutoff = max(timestamp for timestamp, _ in dated_indexes) - cls.INDEX_LOOKBACK
+        selected: list[dict] = []
+        endpoints: set[str] = set()
+        for timestamp, entry in sorted(dated_indexes, key=lambda item: item[0], reverse=True):
+            endpoint = entry['cdx-api']
+            if timestamp >= cutoff and endpoint not in endpoints:
+                endpoints.add(endpoint)
+                selected.append(entry)
+        return selected
 
     async def do_search(self) -> None:
         try:
             headers = {'User-agent': Core.get_user_agent()}
+            catalog_response = await AsyncFetcher.fetch_all(
+                [f'{self.hostname}/collinfo.json'], headers=headers, proxy=self.proxy, json=True
+            )
+            if not catalog_response or not isinstance(catalog_response[0], list) or not catalog_response[0]:
+                print('Common Crawl API error: invalid index catalog')
+                return
 
-            # Use recent Common Crawl indexes
-            indexes = [
-                'CC-MAIN-2024-18',  # April 2024
-                'CC-MAIN-2024-10',  # February 2024
-                'CC-MAIN-2023-50',  # December 2023
-            ]
+            indexes = self._select_indexes(catalog_response[0])
+            if not indexes:
+                print('Common Crawl API error: index catalog contains no usable entries')
+                return
 
             for index in indexes:
                 try:
-                    # Search for subdomains using wildcard
-                    url = f'{self.hostname}/{index}-index?url=*.{self.word}&output=json&limit=1000'
-
-                    response = await AsyncFetcher.fetch_all([url], headers=headers, proxy=self.proxy)
-
-                    if not response or not isinstance(response, list) or not response[0]:
-                        continue
-
-                    try:
-                        data = self._safe_parse_json_lines(response[0])
-                    except Exception as e:
-                        print(f'Failed to parse Common Crawl response for {index}: {e}')
-                        continue
-
-                    # Extract domains from URLs
-                    for record in data:
-                        if isinstance(record, dict):
-                            original_url = record.get('url', '')
-                            if original_url:
-                                domain = self._extract_domain_from_url(original_url)
-
-                                # Check if it's a subdomain of our target
-                                if domain.endswith(f'.{self.word}') or domain == self.word:
-                                    self.totalhosts.add(domain)
-
-                    # Also search for the main domain
-                    main_url = f'{self.hostname}/{index}-index?url={self.word}/*&output=json&limit=100'
-
-                    main_response = await AsyncFetcher.fetch_all([main_url], headers=headers, proxy=self.proxy)
-
-                    if main_response and isinstance(main_response, list) and main_response[0]:
-                        try:
-                            main_data = self._safe_parse_json_lines(main_response[0])
-                            for record in main_data:
+                    endpoint = index['cdx-api']
+                    for query in (f'*.{self.word}', f'{self.word}/*'):
+                        count_url = f'{endpoint}?{urlencode({"url": query, "output": "json", "pageSize": self.PAGE_SIZE, "showNumPages": "true"})}'
+                        count_response = await AsyncFetcher.fetch_all([count_url], headers=headers, proxy=self.proxy)
+                        page_count = json.loads(count_response[0])['pages']
+                        page_urls = [
+                            f'{endpoint}?{urlencode({"url": query, "output": "json", "pageSize": self.PAGE_SIZE, "page": page})}'
+                            for page in range(page_count)
+                        ]
+                        responses = await AsyncFetcher.fetch_all(page_urls, headers=headers, proxy=self.proxy)
+                        for response in responses:
+                            if not response:
+                                raise ValueError('empty page response')
+                            for record in self._safe_parse_json_lines(response):
                                 if isinstance(record, dict):
-                                    original_url = record.get('url', '')
-                                    if original_url:
-                                        domain = self._extract_domain_from_url(original_url)
-                                        if domain.endswith(f'.{self.word}') or domain == self.word:
-                                            self.totalhosts.add(domain)
-                        except Exception as e:
-                            print(f'Failed to parse Common Crawl main domain response for {index}: {e}')
+                                    domain = self._extract_domain_from_url(record.get('url', ''))
+                                    if domain.endswith(f'.{self.word}') or domain == self.word:
+                                        self.totalhosts.add(domain)
 
                 except Exception as e:
-                    print(f'Common Crawl API error for index {index}: {e}')
+                    print(f'Common Crawl API error for index {index.get("id", "unknown")}: {e}')
                     continue
 
         except Exception as e:

--- a/theHarvester/discovery/commoncrawl.py
+++ b/theHarvester/discovery/commoncrawl.py
@@ -34,6 +34,8 @@ class SearchCommoncrawl:
         results: list = []
         if not payload:
             return results
+        if payload.lstrip().startswith('<'):
+            raise ValueError('unexpected non-JSON response')
 
         for line in payload.strip().split('\n'):
             if line.strip():
@@ -97,10 +99,11 @@ class SearchCommoncrawl:
                 print('Common Crawl API error: index catalog contains no usable entries')
                 return
 
+            successful_queries = 0
             for index in indexes:
-                try:
-                    endpoint = index['cdx-api']
-                    for query in (f'*.{self.word}', f'{self.word}/*'):
+                endpoint = index['cdx-api']
+                for query in (f'*.{self.word}', f'{self.word}/*'):
+                    try:
                         count_url = f'{endpoint}?{urlencode({"url": query, "output": "json", "pageSize": self.PAGE_SIZE, "showNumPages": "true"})}'
                         count_response = await AsyncFetcher.fetch_all([count_url], headers=headers, proxy=self.proxy)
                         page_count = json.loads(count_response[0])['pages']
@@ -117,11 +120,15 @@ class SearchCommoncrawl:
                                     domain = self._extract_domain_from_url(record.get('url', ''))
                                     if domain.endswith(f'.{self.word}') or domain == self.word:
                                         self.totalhosts.add(domain)
+                        successful_queries += 1
+                    except Exception as e:
+                        print(f'Common Crawl API error for index {index.get("id", "unknown")}: {e}')
 
-                except Exception as e:
-                    print(f'Common Crawl API error for index {index.get("id", "unknown")}: {e}')
-                    continue
+            if not successful_queries:
+                raise RuntimeError('all Common Crawl queries failed')
 
+        except RuntimeError:
+            raise
         except Exception as e:
             print(f'Common Crawl API error: {e}')
 

--- a/theHarvester/discovery/commoncrawl.py
+++ b/theHarvester/discovery/commoncrawl.py
@@ -1,9 +1,12 @@
 import json as _stdlib_json
+import logging
 from datetime import datetime, timedelta
 from types import ModuleType
 from urllib.parse import urlencode, urlsplit
 
 from theHarvester.lib.core import AsyncFetcher, Core
+
+logger = logging.getLogger(__name__)
 
 json: ModuleType = _stdlib_json
 try:
@@ -58,16 +61,16 @@ class SearchCommoncrawl:
         dated_indexes: list[tuple[datetime, dict]] = []
         for entry in catalog:
             if not isinstance(entry, dict):
-                print('Common Crawl API error for index unknown: invalid catalog entry')
+                logger.warning('Common Crawl API error for index unknown: invalid catalog entry')
                 continue
             index_id = entry.get('id', 'unknown')
             if not isinstance(entry.get('cdx-api'), str):
-                print(f'Common Crawl API error for index {index_id}: invalid catalog entry')
+                logger.warning('Common Crawl API error for index %s: invalid catalog entry', index_id)
                 continue
             try:
                 timestamp = datetime.fromisoformat(str(entry['to'])).replace(tzinfo=None)
             except (KeyError, ValueError):
-                print(f'Common Crawl API error for index {index_id}: invalid catalog entry')
+                logger.warning('Common Crawl API error for index %s: invalid catalog entry', index_id)
                 continue
             dated_indexes.append((timestamp, entry))
 
@@ -91,12 +94,12 @@ class SearchCommoncrawl:
                 [f'{self.hostname}/collinfo.json'], headers=headers, proxy=self.proxy, json=True
             )
             if not catalog_response or not isinstance(catalog_response[0], list) or not catalog_response[0]:
-                print('Common Crawl API error: invalid index catalog')
+                logger.error('Common Crawl API error: invalid index catalog')
                 return
 
             indexes = self._select_indexes(catalog_response[0])
             if not indexes:
-                print('Common Crawl API error: index catalog contains no usable entries')
+                logger.error('Common Crawl API error: index catalog contains no usable entries')
                 return
 
             successful_queries = 0
@@ -122,7 +125,7 @@ class SearchCommoncrawl:
                                         self.totalhosts.add(domain)
                         successful_queries += 1
                     except Exception as e:
-                        print(f'Common Crawl API error for index {index.get("id", "unknown")}: {e}')
+                        logger.warning('Common Crawl API error for index %s: %s', index.get('id', 'unknown'), e)
 
             if not successful_queries:
                 raise RuntimeError('all Common Crawl queries failed')
@@ -130,7 +133,7 @@ class SearchCommoncrawl:
         except RuntimeError:
             raise
         except Exception as e:
-            print(f'Common Crawl API error: {e}')
+            logger.error('Common Crawl API error: %s', e)
 
     async def get_hostnames(self) -> set:
         return self.totalhosts


### PR DESCRIPTION
## Summary

- fetch the current Common Crawl index catalog
- select the bounded current index window
- exhaust result pages instead of stopping at the first page
- identify HTML upstream failures instead of reporting malformed JSON
- preserve partial query results and propagate total query failure

## Validation

`uv run pytest tests/discovery/test_commoncrawl.py`

Result: 6 passed.

