### PR TITLE
Centralize the discovery source catalog

### DIFF
--- a/tests/lib/test_source_catalog.py
+++ b/tests/lib/test_source_catalog.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import ast
+import importlib
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from theHarvester.lib.core import Core
+from theHarvester.lib.source_catalog import (
+    ACTION_ACTIVITIES,
+    SOURCE_CATALOG,
+    ActivityClass,
+    SourceSchedule,
+    canonical_source_names,
+    describe_activity,
+    resolve_sources,
+)
+
+
+def _scheduled_source_names() -> list[str]:
+    tree = ast.parse(Path('theHarvester/__main__.py').read_text())
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare) or len(node.ops) != 1 or not isinstance(node.ops[0], ast.Eq):
+            continue
+        if not isinstance(node.left, ast.Name) or node.left.id != 'engineitem' or len(node.comparators) != 1:
+            continue
+        comparator = node.comparators[0]
+        if isinstance(comparator, ast.Constant) and isinstance(comparator.value, str):
+            names.append(comparator.value)
+    return names
+
+
+def _engine_branches() -> dict[str, list[ast.stmt]]:
+    tree = ast.parse(Path('theHarvester/__main__.py').read_text())
+    branches: dict[str, list[ast.stmt]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If) or not isinstance(node.test, ast.Compare):
+            continue
+        test = node.test
+        if (
+            isinstance(test.left, ast.Name)
+            and test.left.id == 'engineitem'
+            and len(test.ops) == 1
+            and isinstance(test.ops[0], ast.Eq)
+            and len(test.comparators) == 1
+            and isinstance(test.comparators[0], ast.Constant)
+            and isinstance(test.comparators[0].value, str)
+        ):
+            branches[test.comparators[0].value] = node.body
+    return branches
+
+
+def _calls(statements: list[ast.stmt]) -> list[ast.Call]:
+    module = ast.Module(body=statements, type_ignores=[])
+    return [node for node in ast.walk(module) if isinstance(node, ast.Call)]
+
+
+def test_catalog_matches_runnable_scheduler_once() -> None:
+    scheduled = _scheduled_source_names()
+
+    assert len(scheduled) == len(set(scheduled))
+    assert set(scheduled) == set(canonical_source_names())
+    assert {'linkedin', 'linkedin_links', 'netcraft', 'omnisint', 'sublist3r', 'zoomeyeapi'}.isdisjoint(canonical_source_names())
+
+
+def test_every_catalog_adapter_is_importable() -> None:
+    assert len({(source.adapter_module, source.adapter_class) for source in SOURCE_CATALOG}) == len(SOURCE_CATALOG)
+    for source in SOURCE_CATALOG:
+        module = importlib.import_module(f'theHarvester.discovery.{source.adapter_module}')
+        assert isinstance(getattr(module, source.adapter_class), type), source.name
+        assert source.family
+        assert source.capabilities
+        assert source.pagination
+        assert source.recursion
+
+
+def test_catalog_adapter_and_capabilities_match_scheduler_branches() -> None:
+    branches = _engine_branches()
+    capability_keywords = {
+        'store_host': 'hostnames',
+        'store_emails': 'emails',
+        'store_ip': 'ips',
+        'store_people': 'people',
+        'store_links': 'people-links',
+        'store_interestingurls': 'interesting-urls',
+        'store_asns': 'asns',
+    }
+
+    for source in SOURCE_CATALOG:
+        calls = _calls(branches[source.name])
+        constructors = {
+            (call.func.value.id, call.func.attr)
+            for call in calls
+            if isinstance(call.func, ast.Attribute) and isinstance(call.func.value, ast.Name)
+        }
+        assert (source.adapter_module, source.adapter_class) in constructors, source.name
+
+        store_call = next(call for call in calls if isinstance(call.func, ast.Name) and call.func.id == 'store')
+        scheduled_capabilities = {
+            capability_keywords[keyword.arg]
+            for keyword in store_call.keywords
+            if keyword.arg in capability_keywords and isinstance(keyword.value, ast.Constant) and keyword.value.value is True
+        }
+        assert set(source.capabilities) == scheduled_capabilities, source.name
+
+
+def test_catalog_adapter_constructors_do_not_execute_twice_outside_scheduler() -> None:
+    calls = _calls(ast.parse(Path('theHarvester/__main__.py').read_text()).body)
+    counts = {
+        source.name: sum(
+            isinstance(call.func, ast.Attribute)
+            and isinstance(call.func.value, ast.Name)
+            and (call.func.value.id, call.func.attr) == (source.adapter_module, source.adapter_class)
+            for call in calls
+        )
+        for source in SOURCE_CATALOG
+    }
+    assert counts == {source.name: 2 if source.name == 'shodan' else 1 for source in SOURCE_CATALOG}
+
+
+def test_source_schedule_rejects_wrong_adapter_and_duplicates() -> None:
+    plan = resolve_sources('crtsh')
+    schedule = SourceSchedule(plan)
+    module = importlib.import_module('theHarvester.discovery.crtsh')
+    adapter = object.__new__(module.SearchCrtsh)
+
+    with pytest.raises(TypeError, match=r'requires crtsh\.SearchCrtsh'):
+        schedule.register('crtsh', object())
+
+    schedule.register('crtsh', adapter)
+    assert schedule.registrations == (('crtsh', 'crtsh', 'SearchCrtsh'),)
+    with pytest.raises(ValueError, match='scheduled more than once'):
+        schedule.register('crtsh', adapter)
+
+
+def test_dns_and_direct_source_activity_matches_adapter_behavior() -> None:
+    assert {source.name: source.activity for source in SOURCE_CATALOG if source.activity is not ActivityClass.PASSIVE} == {
+        'criminalip': ActivityClass.DIRECT,
+        'pentesttools': ActivityClass.DIRECT,
+        'shodan': ActivityClass.DNS,
+        'shodaninternetdb': ActivityClass.DNS,
+        'windvane': ActivityClass.DNS,
+    }
+
+
+def test_aliases_canonicalize_warn_and_schedule_once() -> None:
+    with pytest.warns(FutureWarning, match='securityTrails.*securitytrails'):
+        plan = resolve_sources(['securityTrails', 'securitytrails'])
+
+    assert plan.names == ('securitytrails',)
+
+
+def test_all_selects_only_passive_sources_and_reports_active_exclusions() -> None:
+    plan = resolve_sources('all')
+
+    assert plan.sources
+    assert {source.activity for source in plan.sources} == {ActivityClass.PASSIVE}
+    assert plan.excluded_names == ('criminalip', 'pentesttools', 'shodan', 'shodaninternetdb', 'windvane')
+    assert plan.exclusion_notice == (
+        "'all' excludes active provider sources: criminalip, pentesttools, shodan, shodaninternetdb, windvane; "
+        "select them explicitly with '-b criminalip,pentesttools,shodan,shodaninternetdb,windvane'."
+    )
+
+
+def test_activity_summary_combines_sources_and_existing_action_options() -> None:
+    plan = resolve_sources(['crtsh', 'pentesttools'])
+
+    assert describe_activity(plan, actions=('dns-resolve', 'take-over', 'screenshot')) == (
+        'Activity: P0 passive=1 source; P1 DNS=enabled; P2 direct=1 source (pentesttools) + take-over, screenshot.'
+    )
+
+    assert describe_activity(resolve_sources(()), actions=('shodan',)) == (
+        'Activity: P0 passive=shodan; P1 DNS=disabled; P2 direct=disabled.'
+    )
+
+
+def test_cli_help_and_availability_share_canonical_names() -> None:
+    from theHarvester import __main__
+
+    source_action = next(action for action in __main__.build_parser()._actions if action.dest == 'source')
+    assert source_action.help == ', '.join(canonical_source_names())
+    assert tuple(Core.get_supportedengines()) == canonical_source_names()
+    assert 'securityTrails' not in source_action.help
+    assert 'shodanInternetDB' not in source_action.help
+
+
+def test_existing_action_options_have_one_activity_class() -> None:
+    assert ACTION_ACTIVITIES == {
+        'dns-brute': ActivityClass.DNS,
+        'dns-lookup': ActivityClass.DNS,
+        'dns-resolve': ActivityClass.DNS,
+        'shodan': ActivityClass.PASSIVE,
+        'api-scan': ActivityClass.DIRECT,
+        'screenshot': ActivityClass.DIRECT,
+        'take-over': ActivityClass.DIRECT,
+    }
+
+
+@pytest.mark.asyncio
+async def test_rest_query_canonicalizes_aliases_before_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    from theHarvester.lib.api import api
+
+    captured_source = ''
+
+    async def fake_start(args):
+        nonlocal captured_source
+        captured_source = args.source
+        return ([], [], [], [], [], [], [], [], [])
+
+    monkeypatch.setattr(api.__main__, 'start', fake_start)
+
+    with pytest.warns(FutureWarning, match='securityTrails.*securitytrails'):
+        response = await api.query.__wrapped__(None, ['securityTrails', 'securitytrails'], 'example.com')
+
+    assert response.status_code == 200
+    assert captured_source == 'securitytrails'
+
+
+@pytest.mark.asyncio
+async def test_rest_all_preserves_passive_selection_notice(monkeypatch: pytest.MonkeyPatch) -> None:
+    from theHarvester.lib.api import api
+
+    captured_source = ''
+
+    async def fake_start(args):
+        nonlocal captured_source
+        captured_source = args.source
+        return ([], [], [], [], [], [], [], [], [])
+
+    monkeypatch.setattr(api.__main__, 'start', fake_start)
+
+    response = await api.query.__wrapped__(None, ['all'], 'example.com')
+
+    assert response.status_code == 200
+    assert captured_source == 'all'
+
+
+@pytest.mark.asyncio
+async def test_cli_and_rest_resolve_equivalent_activity_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    from theHarvester import __main__
+    from theHarvester.lib.api import api
+
+    captured_args = Namespace()
+
+    async def fake_start(args):
+        nonlocal captured_args
+        captured_args = args
+        return ([], [], [], [], [], [], [], [], [])
+
+    monkeypatch.setattr(api.__main__, 'start', fake_start)
+    await api.query.__wrapped__(
+        None,
+        ['all'],
+        'example.com',
+        dns_resolve='1.1.1.1',
+        shodan=True,
+        take_over=True,
+    )
+    cli_args = __main__.build_parser().parse_args(
+        ['-d', 'example.com', '-b', 'all', '--dns-resolve', '1.1.1.1', '--shodan', '--take-over']
+    )
+
+    assert __main__.selected_actions(captured_args) == __main__.selected_actions(cli_args)
+    assert captured_args.source == cli_args.source == 'all'

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -7,7 +7,8 @@ import string
 import sys
 import time
 import traceback
-from typing import TYPE_CHECKING, Any
+from collections.abc import Awaitable
+from typing import Any
 
 import anyio
 import netaddr
@@ -79,10 +80,8 @@ from theHarvester.lib import hostchecker, stash
 from theHarvester.lib.core import DATA_DIR, Core, show_default_error_message
 from theHarvester.lib.output import print_linkedin_sections, print_section, sorted_unique
 from theHarvester.lib.run import LegacyHostnameSource, execute_run, legacy_hostnames
+from theHarvester.lib.source_catalog import SourceSchedule, canonical_source_names, describe_activity, resolve_sources
 from theHarvester.screenshot.screenshot import ScreenShotter
-
-if TYPE_CHECKING:
-    from collections.abc import Awaitable
 
 
 def sanitize_for_xml(text: str) -> str:
@@ -109,8 +108,7 @@ def sanitize_filename(filename: str) -> str:
     return filename
 
 
-async def start(rest_args: argparse.Namespace | None = None):
-    """Main program function"""
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description='theHarvester is used to gather open source intelligence (OSINT) on a company or domain.'
     )
@@ -199,12 +197,31 @@ async def start(rest_args: argparse.Namespace | None = None):
     parser.add_argument(
         '-b',
         '--source',
-        help="""baidu, bevigil, bitbucket, brave, bufferoverun,
-                            builtwith, censys, certspotter, chaos, commoncrawl, criminalip, crtsh, dehashed, dnsdumpster, duckduckgo, dymo, fofa, fullhunt, github-code,
-                            gitlab, hackertarget, haveibeenpwned, hudsonrock, hunter, hunterhow, intelx, leakix, leaklookup, mojeek, netlas, onyphe, otx, pentesttools,
-                            projectdiscovery, rapiddns, robtex, rocketreach, securityscorecard, securityTrails, sherlockeye, shodan, shodanInternetDB, subdomaincenter,
-                            subdomainfinderc99, thc, threatcrowd, tomba, urlscan, venacus, virustotal, waybackarchive, whoisxml, windvane, yahoo, zoomeye""",
+        help=', '.join(canonical_source_names()),
     )
+    return parser
+
+
+def selected_actions(args: argparse.Namespace) -> tuple[str, ...]:
+    dns_resolve = getattr(args, 'dns_resolve', '')
+    return tuple(
+        name
+        for name, enabled in (
+            ('dns-brute', getattr(args, 'dns_brute', False)),
+            ('dns-lookup', getattr(args, 'dns_lookup', False)),
+            ('dns-resolve', dns_resolve is None or bool(dns_resolve)),
+            ('shodan', getattr(args, 'shodan', False)),
+            ('api-scan', getattr(args, 'api_scan', False)),
+            ('screenshot', bool(getattr(args, 'screenshot', ''))),
+            ('take-over', getattr(args, 'take_over', False)),
+        )
+        if enabled
+    )
+
+
+async def start(rest_args: argparse.Namespace | None = None):
+    """Main program function"""
+    parser = build_parser()
 
     # determines if the filename is coming from rest api or user
     rest_filename = ''
@@ -226,6 +243,19 @@ async def start(rest_args: argparse.Namespace | None = None):
         args = parser.parse_args()
         filename = args.filename
         dnsbrute = (args.dns_brute, False)
+
+    try:
+        source_plan = resolve_sources(getattr(args, 'source', '') or ())
+    except ValueError as error:
+        if rest_args is not None:
+            raise
+        print(f'\n[!] {error}.\n')
+        sys.exit(1)
+
+    print(f'[*] {describe_activity(source_plan, actions=selected_actions(args))}')
+    if source_plan.exclusion_notice:
+        print(f'[*] {source_plan.exclusion_notice}')
+
     Core.quiet = getattr(args, 'quiet', False)
     try:
         db = stash.StashManager()
@@ -319,7 +349,9 @@ async def start(rest_args: argparse.Namespace | None = None):
     interesting_urls = []
     total_asns = []
 
-    async def store(
+    execution_schedule = SourceSchedule(source_plan)
+
+    async def _store(
         search_engine: Any,
         source: str,
         process_param: Any = None,
@@ -433,12 +465,19 @@ async def start(rest_args: argparse.Namespace | None = None):
             if len(fasns) > 0:
                 await db.store_all(word, fasns, 'asns', source)
 
+    def store(
+        search_engine: Any,
+        source: str,
+        *args: Any,
+        catalog_adapter: Any = None,
+        **kwargs: Any,
+    ) -> Awaitable[None]:
+        execution_schedule.register(source, catalog_adapter if catalog_adapter is not None else search_engine)
+        return _store(search_engine, source, *args, **kwargs)
+
     stor_lst = []
     if args.source is not None:
-        if args.source.lower() != 'all':
-            engines = sorted(set(map(str.strip, args.source.split(','))))
-        else:
-            engines = Core.get_supportedengines()
+        engines = list(source_plan.names)
         # Iterate through search engines in order
         if set(engines).issubset(Core.get_supportedengines()):
             print(f'\n[*] Target: {word} \n')
@@ -1038,7 +1077,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                         else:
                             print(f'An exception has occurred in SecurityScorecard search: {e}')
 
-                elif engineitem == 'securityTrails':
+                elif engineitem == 'securitytrails':
                     try:
                         securitytrails_search = securitytrailssearch.SearchSecuritytrail(word)
                         stor_lst.append(
@@ -1109,7 +1148,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                                 return list(self.hosts)
 
                         shodan_wrapper = ShodanWrapper(word, shodan_search)
-                        stor_lst.append(store(shodan_wrapper, engineitem, store_host=True))
+                        stor_lst.append(store(shodan_wrapper, engineitem, store_host=True, catalog_adapter=shodan_search))
                     except Exception as e:
                         if isinstance(e, MissingKey):
                             if not args.quiet:
@@ -1117,7 +1156,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                         else:
                             print(f'An exception has occurred in Shodan search: {e}')
 
-                elif engineitem == 'shodanInternetDB':
+                elif engineitem == 'shodaninternetdb':
                     try:
                         shodanidb_search = shodan_internetdb.SearchShodanInternetDB(word)
                         stor_lst.append(
@@ -1893,60 +1932,6 @@ async def start(rest_args: argparse.Namespace | None = None):
             print(f'\n[!] An exception has occurred in API Endpoints scanning: {e}')
             print('    Continuing with the rest of the scan...')
             traceback.print_exc()  # More detailed error information for developers
-
-    if 'securityscorecard' in engines:
-        try:
-            print('\n[*] Performing SecurityScorecard scan...')
-            securityscorecard_scanner = securityscorecard.SearchSecurityScorecard(word)
-            await securityscorecard_scanner.process(use_proxy)
-
-            # Use the existing API to get results
-            hosts = await securityscorecard_scanner.get_hostnames()
-            if hosts:
-                print(f'\n[*] SecurityScorecard results: {len(hosts)} hosts found')
-                for host in hosts:
-                    print(f'    - {host}')
-
-                all_hosts.extend(hosts)
-
-            ips = await securityscorecard_scanner.get_ips()
-            if ips:
-                print(f'\n[*] SecurityScorecard IPs found: {len(ips)}')
-                for ip in ips:
-                    print(f'    - {ip}')
-                all_ip.extend(ips)
-
-        except Exception as e:
-            print(f'An exception has occurred in SecurityScorecard scanning: {e}')
-
-    if 'builtwith' in engines:
-        try:
-            print('\n[*] Performing BuiltWith scan...')
-            builtwith_scanner = builtwith.SearchBuiltWith(word)
-            await builtwith_scanner.process(use_proxy)
-
-            hosts = await builtwith_scanner.get_hostnames()
-            if hosts:
-                print(f'\n[*] BuiltWith results: {len(hosts)} hosts found')
-                for host in hosts:
-                    print(f'    - {host}')
-
-                # Add results to the main host list
-                all_hosts.extend(hosts)
-
-            urls = list(await builtwith_scanner.get_interesting_urls())
-            if urls:
-                print(f'\n[*] BuiltWith interesting URLs found: {len(urls)}')
-                for url in urls:
-                    print(f'    - {url}')
-                interesting_urls.extend(urls)
-
-        except Exception as e:
-            if isinstance(e, MissingKey):
-                if not args.quiet:
-                    print(MissingKey('BuiltWith'))
-                else:
-                    print(f'An exception has occurred in BuiltWith scanning: {e}')
 
     if rest_args is not None:
         all_hosts = sorted({host.replace('www.', '') for host in all_hosts})

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -17,6 +17,7 @@ from starlette.staticfiles import StaticFiles
 
 from theHarvester import __main__
 from theHarvester.lib.api.additional_endpoints import router as additional_router
+from theHarvester.lib.source_catalog import resolve_sources
 
 API_RATE_LIMIT = os.getenv('API_RATE_LIMIT', '5/minute')
 
@@ -316,14 +317,13 @@ async def query(
         return response
 
     try:
-        # Validate sources
-        supported_engines = __main__.Core.get_supportedengines()
-        for s in source:
-            if s not in supported_engines:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Source '{s}' is not supported. Supported sources: {', '.join(supported_engines)}",
-                )
+        try:
+            source_plan = resolve_sources(source)
+        except ValueError as error:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f'{error}. Supported sources: {", ".join(__main__.Core.get_supportedengines())}',
+            ) from error
 
         if api_scan and not await _is_public_target(domain):
             raise HTTPException(
@@ -352,7 +352,7 @@ async def query(
                 limit=limit,
                 proxies=proxies,
                 shodan=shodan,
-                source=','.join(source),
+                source='all' if source_plan.excluded else ','.join(source_plan.names),
                 start=start,
                 take_over=take_over,
                 wordlist=wordlist,

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -16,6 +16,7 @@ import yaml
 from aiohttp_socks import ProxyConnector
 
 from theHarvester import __version__
+from theHarvester.lib.source_catalog import canonical_source_names
 
 if TYPE_CHECKING:
     from collections.abc import Sized
@@ -276,69 +277,7 @@ class Core:
     @staticmethod
     def get_supportedengines() -> list[str]:
         """Returns a list of supported search engines."""
-        return [
-            'baidu',
-            'bevigil',
-            'bitbucket',
-            'bufferoverun',
-            'builtwith',
-            'brave',
-            'censys',
-            'certspotter',
-            'chaos',
-            'commoncrawl',
-            'criminalip',
-            'crtsh',
-            'dehashed',
-            'dnsdumpster',
-            'duckduckgo',
-            'dymo',
-            'fofa',
-            'fullhunt',
-            'github-code',
-            'gitlab',
-            'hackertarget',
-            'haveibeenpwned',
-            'hudsonrock',
-            'hunter',
-            'hunterhow',
-            'intelx',
-            'leakix',
-            'leaklookup',
-            'linkedin',
-            'linkedin_links',
-            'mojeek',
-            'netcraft',
-            'netlas',
-            'omnisint',
-            'onyphe',
-            'otx',
-            'pentesttools',
-            'projectdiscovery',
-            'rapiddns',
-            'robtex',
-            'rocketreach',
-            'securityscorecard',
-            'securityTrails',
-            'sherlockeye',
-            'shodan',
-            'shodanInternetDB',
-            'subdomaincenter',
-            'subdomainfinderc99',
-            'sublist3r',
-            'thc',
-            'threatcrowd',
-            'tomba',
-            'urlscan',
-            'venacus',
-            'virustotal',
-            'waybackarchive',
-            'whoisxml',
-            'windvane',
-            'yahoo',
-            'zoomeye',
-            'zoomeyeapi',
-        ]
+        return list(canonical_source_names())
 
     @staticmethod
     def get_user_agent() -> str:

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -1,0 +1,523 @@
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from enum import StrEnum
+from importlib import import_module
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+class ActivityClass(StrEnum):
+    PASSIVE = 'P0'
+    DNS = 'P1'
+    DIRECT = 'P2'
+
+
+ACTION_ACTIVITIES: Final = {
+    'dns-brute': ActivityClass.DNS,
+    'dns-lookup': ActivityClass.DNS,
+    'dns-resolve': ActivityClass.DNS,
+    'shodan': ActivityClass.PASSIVE,
+    'api-scan': ActivityClass.DIRECT,
+    'screenshot': ActivityClass.DIRECT,
+    'take-over': ActivityClass.DIRECT,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class SourceSpec:
+    name: str
+    adapter_module: str
+    adapter_class: str
+    family: str
+    credentials: tuple[str, ...]
+    capabilities: tuple[str, ...]
+    activity: ActivityClass = ActivityClass.PASSIVE
+    pagination: str = 'adapter-managed'
+    recursion: str = 'none'
+    declared_limits: tuple[str, ...] = ()
+    aliases: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class SourcePlan:
+    sources: tuple[SourceSpec, ...]
+    excluded: tuple[SourceSpec, ...] = ()
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        return tuple(source.name for source in self.sources)
+
+    @property
+    def excluded_names(self) -> tuple[str, ...]:
+        return tuple(source.name for source in self.excluded)
+
+    @property
+    def exclusion_notice(self) -> str:
+        if not self.excluded:
+            return ''
+        names = ', '.join(self.excluded_names)
+        selection = ','.join(self.excluded_names)
+        return f"'all' excludes active provider sources: {names}; select them explicitly with '-b {selection}'."
+
+
+def _source(
+    name: str,
+    adapter_module: str,
+    adapter_class: str,
+    *,
+    family: str,
+    credentials: tuple[str, ...] = (),
+    capabilities: tuple[str, ...] = ('hostnames',),
+    activity: ActivityClass = ActivityClass.PASSIVE,
+    pagination: str = 'adapter-managed',
+    recursion: str = 'none',
+    limits: tuple[str, ...] = (),
+    aliases: tuple[str, ...] = (),
+) -> SourceSpec:
+    return SourceSpec(
+        name=name,
+        adapter_module=adapter_module,
+        adapter_class=adapter_class,
+        family=family,
+        credentials=credentials,
+        capabilities=capabilities,
+        activity=activity,
+        pagination=pagination,
+        recursion=recursion,
+        declared_limits=limits,
+        aliases=aliases,
+    )
+
+
+class SourceSchedule:
+    def __init__(self, plan: SourcePlan) -> None:
+        self._selected = {source.name: source for source in plan.sources}
+        self._registrations: dict[str, tuple[str, str]] = {}
+
+    @property
+    def registrations(self) -> tuple[tuple[str, str, str], ...]:
+        return tuple((name, *adapter) for name, adapter in sorted(self._registrations.items()))
+
+    def register(self, name: str, adapter: object) -> None:
+        source = _BY_NAME.get(name.casefold())
+        if source is None or source.name not in self._selected:
+            raise ValueError(f"Source '{name}' is not in the execution plan")
+        if source.name in self._registrations:
+            raise ValueError(f"Source '{source.name}' was scheduled more than once")
+        adapter_type = getattr(import_module(f'theHarvester.discovery.{source.adapter_module}'), source.adapter_class)
+        if not isinstance(adapter, adapter_type):
+            actual = (adapter.__class__.__module__.rsplit('.', 1)[-1], adapter.__class__.__name__)
+            raise TypeError(
+                f"Source '{source.name}' requires {source.adapter_module}.{source.adapter_class}, got {actual[0]}.{actual[1]}"
+            )
+        self._registrations[source.name] = (source.adapter_module, source.adapter_class)
+
+
+_LIMIT: Final = ('operator-result-limit',)
+
+SOURCE_CATALOG: Final[tuple[SourceSpec, ...]] = (
+    _source('baidu', 'baidusearch', 'SearchBaidu', family='web-search', capabilities=('hostnames', 'emails'), limits=_LIMIT),
+    _source(
+        'bevigil',
+        'bevigil',
+        'SearchBeVigil',
+        family='bevigil',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'interesting-urls'),
+    ),
+    _source(
+        'bitbucket',
+        'bitbucket',
+        'SearchBitBucket',
+        family='source-code',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'emails'),
+        limits=_LIMIT,
+    ),
+    _source(
+        'brave',
+        'bravesearch',
+        'SearchBrave',
+        family='web-search',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'emails'),
+        limits=_LIMIT,
+    ),
+    _source(
+        'bufferoverun',
+        'bufferoverun',
+        'SearchBufferover',
+        family='passive-dns',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'ips'),
+    ),
+    _source(
+        'builtwith',
+        'builtwith',
+        'SearchBuiltWith',
+        family='builtwith',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'interesting-urls'),
+    ),
+    _source(
+        'censys',
+        'censysearch',
+        'SearchCensys',
+        family='censys',
+        credentials=('api-id', 'api-secret'),
+        capabilities=('hostnames', 'emails'),
+        limits=_LIMIT,
+    ),
+    _source(
+        'certspotter',
+        'certspottersearch',
+        'SearchCertspoter',
+        family='certificate-transparency',
+        pagination='cursor-until-exhausted',
+        limits=('maximum-pages-1000',),
+    ),
+    _source(
+        'chaos', 'chaos', 'SearchChaos', family='projectdiscovery', credentials=('api-key',), recursion='provider-descendants'
+    ),
+    _source('commoncrawl', 'commoncrawl', 'SearchCommoncrawl', family='web-archive', pagination='all-current-indexes'),
+    _source(
+        'criminalip',
+        'criminalip',
+        'SearchCriminalIP',
+        family='criminalip',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'ips', 'asns'),
+        activity=ActivityClass.DIRECT,
+    ),
+    _source('crtsh', 'crtsh', 'SearchCrtsh', family='certificate-transparency'),
+    _source(
+        'dehashed', 'search_dehashed', 'SearchDehashed', family='breach-data', credentials=('api-key',), capabilities=('ips',)
+    ),
+    _source(
+        'dnsdumpster',
+        'search_dnsdumpster',
+        'SearchDNSDumpster',
+        family='dnsdumpster',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'ips'),
+    ),
+    _source(
+        'duckduckgo',
+        'duckduckgosearch',
+        'SearchDuckDuckGo',
+        family='web-search',
+        capabilities=('hostnames', 'emails'),
+        limits=_LIMIT,
+    ),
+    _source('dymo', 'dymosearch', 'SearchDymo', family='dymo', credentials=('api-key',)),
+    _source(
+        'fofa', 'fofa', 'SearchFofa', family='fofa', credentials=('api-key', 'account-email'), capabilities=('hostnames', 'ips')
+    ),
+    _source('fullhunt', 'fullhuntsearch', 'SearchFullHunt', family='fullhunt', credentials=('api-key',)),
+    _source(
+        'github-code',
+        'githubcode',
+        'SearchGithubCode',
+        family='source-code',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'emails'),
+        limits=_LIMIT,
+    ),
+    _source('gitlab', 'gitlabsearch', 'SearchGitlab', family='source-code', capabilities=('hostnames', 'emails')),
+    _source(
+        'hackertarget',
+        'hackertarget',
+        'SearchHackerTarget',
+        family='hackertarget',
+        credentials=('api-key',),
+        capabilities=('hostnames',),
+    ),
+    _source(
+        'haveibeenpwned',
+        'haveibeenpwned',
+        'SearchHaveIBeenPwned',
+        family='breach-data',
+        credentials=('api-key',),
+        capabilities=('emails',),
+    ),
+    _source(
+        'hudsonrock',
+        'hudsonrocksearch',
+        'SearchHudsonRock',
+        family='breach-data',
+        capabilities=('hostnames', 'emails', 'ips'),
+    ),
+    _source(
+        'hunter',
+        'huntersearch',
+        'SearchHunter',
+        family='hunter',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'emails'),
+        limits=_LIMIT,
+    ),
+    _source('hunterhow', 'searchhunterhow', 'SearchHunterHow', family='hunterhow', credentials=('api-key',)),
+    _source(
+        'intelx',
+        'intelxsearch',
+        'SearchIntelx',
+        family='intelx',
+        credentials=('api-key',),
+        capabilities=('emails', 'interesting-urls'),
+    ),
+    _source(
+        'leakix',
+        'leakix',
+        'SearchLeakix',
+        family='leakix',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'emails'),
+    ),
+    _source(
+        'leaklookup',
+        'leaklookup',
+        'SearchLeakLookup',
+        family='breach-data',
+        credentials=('api-key',),
+        capabilities=('emails',),
+    ),
+    _source(
+        'mojeek',
+        'mojeek',
+        'SearchMojeek',
+        family='web-search',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'emails'),
+        limits=_LIMIT,
+    ),
+    _source(
+        'netlas',
+        'netlas',
+        'SearchNetlas',
+        family='netlas',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'ips'),
+        limits=_LIMIT,
+    ),
+    _source(
+        'onyphe',
+        'onyphe',
+        'SearchOnyphe',
+        family='onyphe',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'ips', 'asns'),
+    ),
+    _source('otx', 'otxsearch', 'SearchOtx', family='alienvault-otx', capabilities=('hostnames', 'ips')),
+    _source(
+        'pentesttools',
+        'pentesttools',
+        'SearchPentestTools',
+        family='pentesttools',
+        credentials=('api-key',),
+        activity=ActivityClass.DIRECT,
+        limits=('provider-scan-budget',),
+    ),
+    _source(
+        'projectdiscovery',
+        'projectdiscovery',
+        'SearchDiscovery',
+        family='projectdiscovery',
+        credentials=('api-key',),
+        recursion='provider-descendants',
+    ),
+    _source('rapiddns', 'rapiddns', 'SearchRapidDns', family='rapiddns'),
+    _source('robtex', 'robtex', 'SearchRobtex', family='robtex', capabilities=('hostnames', 'ips')),
+    _source(
+        'rocketreach',
+        'rocketreach',
+        'SearchRocketReach',
+        family='rocketreach',
+        credentials=('api-key',),
+        capabilities=('emails', 'people-links'),
+        limits=_LIMIT,
+    ),
+    _source(
+        'securityscorecard',
+        'securityscorecard',
+        'SearchSecurityScorecard',
+        family='securityscorecard',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'ips', 'interesting-urls', 'asns'),
+    ),
+    _source(
+        'securitytrails',
+        'securitytrailssearch',
+        'SearchSecuritytrail',
+        family='securitytrails',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'ips'),
+        aliases=('securityTrails',),
+    ),
+    _source(
+        'sherlockeye',
+        'sherlockeye',
+        'SearchSherlockeye',
+        family='sherlockeye',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'emails', 'ips'),
+    ),
+    _source('shodan', 'shodansearch', 'SearchShodan', family='shodan', credentials=('api-key',), activity=ActivityClass.DNS),
+    _source(
+        'shodaninternetdb',
+        'shodan_internetdb',
+        'SearchShodanInternetDB',
+        family='shodan',
+        capabilities=('hostnames', 'ips'),
+        activity=ActivityClass.DNS,
+        aliases=('shodanInternetDB',),
+    ),
+    _source('subdomaincenter', 'subdomaincenter', 'SubdomainCenter', family='subdomaincenter'),
+    _source(
+        'subdomainfinderc99',
+        'subdomainfinderc99',
+        'SearchSubdomainfinderc99',
+        family='subdomainfinderc99',
+    ),
+    _source('thc', 'thc', 'SearchThc', family='thc', limits=('provider-result-limit-10000',)),
+    _source('threatcrowd', 'threatcrowd', 'SearchThreatcrowd', family='threatcrowd', capabilities=('hostnames', 'ips')),
+    _source(
+        'tomba',
+        'tombasearch',
+        'SearchTomba',
+        family='tomba',
+        credentials=('api-key', 'api-secret'),
+        capabilities=('hostnames', 'emails'),
+        limits=_LIMIT,
+    ),
+    _source(
+        'urlscan', 'urlscan', 'SearchUrlscan', family='urlscan', capabilities=('hostnames', 'ips', 'interesting-urls', 'asns')
+    ),
+    _source(
+        'venacus',
+        'venacussearch',
+        'SearchVenacus',
+        family='venacus',
+        credentials=('api-key',),
+        capabilities=('emails', 'ips', 'people', 'interesting-urls'),
+        limits=_LIMIT,
+    ),
+    _source('virustotal', 'virustotal', 'SearchVirustotal', family='virustotal', credentials=('api-key',)),
+    _source(
+        'waybackarchive',
+        'waybackarchive',
+        'SearchWaybackarchive',
+        family='web-archive',
+        pagination='resume-key-until-exhausted',
+        limits=('page-size-1000', 'maximum-pages-per-query-1000'),
+    ),
+    _source('whoisxml', 'whoisxml', 'SearchWhoisXML', family='whoisxml', credentials=('api-key',)),
+    _source(
+        'windvane',
+        'windvane',
+        'SearchWindvane',
+        family='windvane',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'emails', 'ips'),
+        activity=ActivityClass.DNS,
+        limits=('dns-fallback-labels-20',),
+    ),
+    _source('yahoo', 'yahoosearch', 'SearchYahoo', family='web-search', capabilities=('hostnames', 'emails'), limits=_LIMIT),
+    _source(
+        'zoomeye',
+        'zoomeyesearch',
+        'SearchZoomEye',
+        family='zoomeye',
+        credentials=('api-key',),
+        capabilities=('hostnames', 'emails', 'ips', 'interesting-urls', 'asns'),
+        limits=_LIMIT,
+    ),
+)
+
+_BY_NAME: Final = {source.name: source for source in SOURCE_CATALOG}
+_BY_ALIAS: Final = {alias: source for source in SOURCE_CATALOG for alias in source.aliases}
+_BY_CASEFOLD: Final = {source.name.casefold(): source for source in SOURCE_CATALOG}
+
+
+def canonical_source_names() -> tuple[str, ...]:
+    return tuple(sorted(_BY_NAME))
+
+
+def _tokens(selection: str | Iterable[str]) -> list[str]:
+    values = [selection] if isinstance(selection, str) else selection
+    return [token.strip() for value in values for token in value.split(',') if token.strip()]
+
+
+def resolve_sources(selection: str | Iterable[str]) -> SourcePlan:
+    requested = _tokens(selection)
+    if len(requested) == 1 and requested[0].casefold() == 'all':
+        passive = tuple(
+            sorted(
+                (source for source in SOURCE_CATALOG if source.activity is ActivityClass.PASSIVE), key=lambda source: source.name
+            )
+        )
+        excluded = tuple(
+            sorted(
+                (source for source in SOURCE_CATALOG if source.activity is not ActivityClass.PASSIVE),
+                key=lambda source: source.name,
+            )
+        )
+        return SourcePlan(passive, excluded)
+
+    resolved: dict[str, SourceSpec] = {}
+    unsupported: list[str] = []
+    for name in requested:
+        source = _BY_NAME.get(name)
+        if source is None and name in _BY_ALIAS:
+            source = _BY_ALIAS[name]
+            warnings.warn(
+                f"Source alias '{name}' is deprecated; use '{source.name}'.",
+                FutureWarning,
+                stacklevel=2,
+            )
+        if source is None:
+            source = _BY_CASEFOLD.get(name.casefold())
+        if source is None:
+            unsupported.append(name)
+        else:
+            resolved[source.name] = source
+
+    if unsupported:
+        raise ValueError(f'Unsupported sources: {", ".join(sorted(unsupported))}')
+    return SourcePlan(tuple(resolved[name] for name in sorted(resolved)))
+
+
+def describe_activity(
+    plan: SourcePlan,
+    *,
+    actions: Iterable[str] = (),
+) -> str:
+    selected_actions = tuple(actions)
+    unknown = set(selected_actions) - set(ACTION_ACTIVITIES)
+    if unknown:
+        raise ValueError(f'Unclassified actions: {", ".join(sorted(unknown))}')
+    passive_count = sum(source.activity is ActivityClass.PASSIVE for source in plan.sources)
+    passive_actions = tuple(action for action in selected_actions if ACTION_ACTIVITIES[action] is ActivityClass.PASSIVE)
+    passive_parts: list[str] = []
+    if passive_count:
+        noun = 'source' if passive_count == 1 else 'sources'
+        passive_parts.append(f'{passive_count} {noun}')
+    if passive_actions:
+        passive_parts.append(', '.join(passive_actions))
+    passive = ' + '.join(passive_parts) if passive_parts else 'disabled'
+    dns = any(source.activity is ActivityClass.DNS for source in plan.sources) or any(
+        ACTION_ACTIVITIES[action] is ActivityClass.DNS for action in selected_actions
+    )
+    direct_sources = tuple(source.name for source in plan.sources if source.activity is ActivityClass.DIRECT)
+    direct_actions = tuple(action for action in selected_actions if ACTION_ACTIVITIES[action] is ActivityClass.DIRECT)
+    direct_parts: list[str] = []
+    if direct_sources:
+        noun = 'source' if len(direct_sources) == 1 else 'sources'
+        direct_parts.append(f'{len(direct_sources)} {noun} ({", ".join(direct_sources)})')
+    if direct_actions:
+        direct_parts.append(', '.join(direct_actions))
+    direct = ' + '.join(direct_parts) if direct_parts else 'disabled'
+    return f'Activity: P0 passive={passive}; P1 DNS={"enabled" if dns else "disabled"}; P2 direct={direct}.'


### PR DESCRIPTION
## Summary

- centralize discovery-source metadata and aliases
- make CLI and REST source selection use the same catalog
- cover catalog completeness, importability, and alias behavior

## Stack

Depends on `codex/evidence-runs`. Review only this PR's one-commit delta; merge after the evidence-runs PR.

## Validation

`uv run pytest tests/lib/test_source_catalog.py`

Result: 14 passed.

