### PR TITLE
Add bounded recursive DNS discovery

### DIFF
--- a/tests/lib/test_recursive_dns.py
+++ b/tests/lib/test_recursive_dns.py
@@ -1,0 +1,400 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from argparse import Namespace
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import ClassVar
+from xml.etree import ElementTree
+
+import pytest
+
+from theHarvester.lib.output import evidence_xml_fragment, format_run_terminal, legacy_json_result, run_result_jsonl
+from theHarvester.lib.run import (
+    Addressability,
+    Derivation,
+    DNSResponse,
+    RecursiveDNSLimits,
+    ScopeClass,
+    SourceFinding,
+    execute_run,
+    run_recursive_dns,
+)
+
+
+class SeedSource:
+    name = 'fixture'
+    family = 'fixture-family'
+
+    async def collect(self, _target: str) -> list[SourceFinding]:
+        return [
+            SourceFinding('api.example.com'),
+            SourceFinding('empty.example.com'),
+            SourceFinding('outside.example.net', Derivation.RELATED),
+            SourceFinding('cdn.vendor.test', Derivation.EXTERNAL_RELATIONSHIP),
+        ]
+
+
+class SingleSeedSource:
+    name = 'fixture'
+    family = 'fixture-family'
+
+    async def collect(self, _target: str) -> list[SourceFinding]:
+        return [SourceFinding('api.example.com')]
+
+
+class FakeRecursiveResolver:
+    current: ClassVar[set[str]] = {
+        'api.example.com',
+        'empty.example.com',
+        'dev.api.example.com',
+        'v2.dev.api.example.com',
+    }
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.queries: list[str] = []
+
+    async def query(self, hostname: str) -> DNSResponse:
+        self.queries.append(hostname)
+        if hostname in self.current:
+            return DNSResponse(ipv4=('192.0.2.10',), ttl=60)
+        return DNSResponse(rcode='NXDOMAIN')
+
+
+class BlockingResolver:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.started = asyncio.Event()
+        self.cancelled = 0
+
+    async def query(self, _hostname: str) -> DNSResponse:
+        self.started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled += 1
+            raise
+
+
+class NestedWildcardResolver(FakeRecursiveResolver):
+    current: ClassVar[set[str]] = {
+        'api.example.com',
+        'dev.api.example.com',
+        'v2.dev.api.example.com',
+    }
+
+    async def query(self, hostname: str) -> DNSResponse:
+        self.queries.append(hostname)
+        if hostname.startswith('th-') and hostname.endswith('.dev.api.example.com'):
+            return DNSResponse(ipv4=('192.0.2.99',), ttl=60)
+        if hostname in self.current:
+            return DNSResponse(ipv4=('192.0.2.10',), ttl=60)
+        return DNSResponse(rcode='NXDOMAIN')
+
+
+class DisputedResolver(FakeRecursiveResolver):
+    async def query(self, hostname: str) -> DNSResponse:
+        self.queries.append(hostname)
+        if hostname == 'api.example.com':
+            return DNSResponse(ipv4=('192.0.2.10',), ttl=60)
+        if hostname == 'dev.api.example.com':
+            if self.name == 'resolver-0':
+                return DNSResponse(ipv4=('192.0.2.11',), ttl=60)
+            if self.name == 'resolver-1':
+                return DNSResponse(rcode='NXDOMAIN')
+            return DNSResponse(rcode='ERROR', error='timeout')
+        return DNSResponse(rcode='NXDOMAIN')
+
+
+class ExpiringLabels(Sequence[str]):
+    def __len__(self) -> int:
+        return 1
+
+    def __getitem__(self, index: int) -> str:
+        if index:
+            raise IndexError
+        time.sleep(0.01)
+        return 'dev'
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_expands_current_parents_breadth_first_with_parent_provenance() -> None:
+    resolvers = tuple(FakeRecursiveResolver(f'resolver-{index}') for index in range(3))
+    result = await execute_run('example.com', SeedSource(), resolver_vantages=resolvers, persist=False)
+    for resolver in resolvers:
+        resolver.queries.clear()
+
+    result = await run_recursive_dns(
+        result,
+        resolvers,
+        ('dev', 'v2'),
+        RecursiveDNSLimits(depth=2, query_limit=1_000, runtime_seconds=5),
+    )
+
+    recursive = [observation for observation in result.observations if observation.derivation is Derivation.RECURSIVE_DNS]
+    assert {(observation.value, observation.parent) for observation in recursive} == {
+        ('dev.api.example.com', 'api.example.com'),
+        ('v2.api.example.com', 'api.example.com'),
+        ('dev.empty.example.com', 'empty.example.com'),
+        ('v2.empty.example.com', 'empty.example.com'),
+        ('dev.dev.api.example.com', 'dev.api.example.com'),
+        ('v2.dev.api.example.com', 'dev.api.example.com'),
+    }
+    entities = {entity.value: entity for entity in result.entities}
+    assert entities['dev.api.example.com'].addressability is Addressability.CURRENT
+    assert entities['v2.dev.api.example.com'].addressability is Addressability.CURRENT
+    assert entities['v2.api.example.com'].addressability is Addressability.NOT_CURRENT
+    assert all(ScopeClass.IN_SCOPE in entities[observation.value].scope_classes for observation in recursive)
+    assert all(
+        entity.value != 'outside.example.net' or entity.addressability is Addressability.UNVERIFIED for entity in result.entities
+    )
+    assert not any('outside.example.net' in query for resolver in resolvers for query in resolver.queries)
+    assert not any('cdn.vendor.test' in query for resolver in resolvers for query in resolver.queries)
+    execution = result.source_executions[-1]
+    assert execution.source == 'action:dns-recursive'
+    assert execution.result_count == 2
+    assert execution.query_count == 45
+    assert execution.depth_reached == 2
+    assert execution.stop_reason == 'depth-limit'
+    assert result.completed_at >= datetime(2026, 1, 1, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_stops_before_exceeding_the_query_budget() -> None:
+    resolvers = tuple(FakeRecursiveResolver(f'resolver-{index}') for index in range(3))
+    result = await execute_run('example.com', SeedSource(), resolver_vantages=resolvers, persist=False)
+    for resolver in resolvers:
+        resolver.queries.clear()
+
+    result = await run_recursive_dns(
+        result,
+        resolvers,
+        ('dev',),
+        RecursiveDNSLimits(depth=2, query_limit=11, runtime_seconds=5),
+    )
+
+    execution = result.source_executions[-1]
+    assert execution.query_count == 0
+    assert execution.depth_reached == 0
+    assert execution.stop_reason == 'query-limit'
+    assert not [observation for observation in result.observations if observation.derivation is Derivation.RECURSIVE_DNS]
+    assert not any(resolver.queries for resolver in resolvers)
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_runtime_limit_cancels_queries_and_preserves_the_cost() -> None:
+    seed_resolvers = tuple(FakeRecursiveResolver(f'seed-{index}') for index in range(3))
+    result = await execute_run('example.com', SeedSource(), resolver_vantages=seed_resolvers, persist=False)
+    resolvers = tuple(BlockingResolver(f'resolver-{index}') for index in range(3))
+
+    result = await run_recursive_dns(
+        result,
+        resolvers,
+        ('dev',),
+        RecursiveDNSLimits(depth=2, query_limit=100, runtime_seconds=0.01),
+    )
+
+    execution = result.source_executions[-1]
+    assert execution.query_count == 9
+    assert execution.depth_reached == 0
+    assert execution.stop_reason == 'runtime-limit'
+    assert sum(resolver.cancelled for resolver in resolvers) == 9
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_runtime_limit_includes_label_preprocessing() -> None:
+    resolvers = tuple(FakeRecursiveResolver(f'resolver-{index}') for index in range(3))
+    result = await execute_run('example.com', SingleSeedSource(), resolver_vantages=resolvers, persist=False)
+    for resolver in resolvers:
+        resolver.queries.clear()
+
+    result = await run_recursive_dns(
+        result,
+        resolvers,
+        ExpiringLabels(),
+        RecursiveDNSLimits(depth=2, query_limit=100, runtime_seconds=0.001),
+    )
+
+    execution = result.source_executions[-1]
+    assert execution.query_count == 0
+    assert execution.stop_reason == 'runtime-limit'
+    assert not any(resolver.queries for resolver in resolvers)
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_external_cancellation_propagates_after_cancelling_queries() -> None:
+    seed_resolvers = tuple(FakeRecursiveResolver(f'seed-{index}') for index in range(3))
+    result = await execute_run('example.com', SeedSource(), resolver_vantages=seed_resolvers, persist=False)
+    resolvers = tuple(BlockingResolver(f'resolver-{index}') for index in range(3))
+    task = asyncio.create_task(
+        run_recursive_dns(
+            result,
+            resolvers,
+            ('dev',),
+            RecursiveDNSLimits(depth=2, query_limit=100, runtime_seconds=60),
+        )
+    )
+    await asyncio.gather(*(resolver.started.wait() for resolver in resolvers))
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert sum(resolver.cancelled for resolver in resolvers) == 9
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_stops_after_three_consecutive_zero_yield_batches() -> None:
+    resolvers = tuple(FakeRecursiveResolver(f'resolver-{index}') for index in range(3))
+    result = await execute_run('example.com', SingleSeedSource(), resolver_vantages=resolvers, persist=False)
+    for resolver in resolvers:
+        resolver.queries.clear()
+
+    result = await run_recursive_dns(
+        result,
+        resolvers,
+        tuple(f'unused{index}' for index in range(151)),
+        RecursiveDNSLimits(depth=2, query_limit=1_000, runtime_seconds=5),
+    )
+
+    execution = result.source_executions[-1]
+    recursive = [observation for observation in result.observations if observation.derivation is Derivation.RECURSIVE_DNS]
+    assert len(recursive) == 150
+    assert execution.query_count == 459
+    assert execution.depth_reached == 0
+    assert execution.zero_yield_batches == 3
+    assert execution.stop_reason == 'zero-yield'
+    assert 'unused150.api.example.com' not in {observation.value for observation in recursive}
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_nested_wildcard_never_advances_or_queries_out_of_scope_labels() -> None:
+    resolvers = tuple(NestedWildcardResolver(f'resolver-{index}') for index in range(3))
+    result = await execute_run('example.com', SingleSeedSource(), resolver_vantages=resolvers, persist=False)
+    for resolver in resolvers:
+        resolver.queries.clear()
+
+    result = await run_recursive_dns(
+        result,
+        resolvers,
+        ('dev', 'v2', 'escape.example.net'),
+        RecursiveDNSLimits(depth=3, query_limit=1_000, runtime_seconds=5),
+    )
+
+    entities = {entity.value: entity for entity in result.entities}
+    assert entities['v2.dev.api.example.com'].addressability is Addressability.WILDCARD_UNCERTAIN
+    assert 'dev.v2.dev.api.example.com' not in entities
+    assert not any('escape.example.net' in query for resolver in resolvers for query in resolver.queries)
+    execution = result.source_executions[-1]
+    assert execution.depth_reached == 2
+    assert execution.stop_reason == 'frontier-exhausted'
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_disputed_names_never_advance_the_frontier() -> None:
+    seed_resolvers = tuple(FakeRecursiveResolver(f'seed-{index}') for index in range(3))
+    result = await execute_run('example.com', SingleSeedSource(), resolver_vantages=seed_resolvers, persist=False)
+    resolvers = tuple(DisputedResolver(f'resolver-{index}') for index in range(3))
+
+    result = await run_recursive_dns(
+        result,
+        resolvers,
+        ('dev',),
+        RecursiveDNSLimits(depth=2, query_limit=100, runtime_seconds=5),
+    )
+
+    entities = {entity.value: entity for entity in result.entities}
+    assert entities['dev.api.example.com'].addressability is Addressability.RESOLVER_DISPUTED
+    assert 'dev.dev.api.example.com' not in entities
+    assert not any('dev.dev.api.example.com' in query for resolver in resolvers for query in resolver.queries)
+
+
+@pytest.mark.asyncio
+async def test_recursive_dns_provenance_and_cost_are_visible_on_every_output_surface() -> None:
+    resolvers = tuple(FakeRecursiveResolver(f'resolver-{index}') for index in range(3))
+    result = await execute_run('example.com', SingleSeedSource(), resolver_vantages=resolvers, persist=False)
+    result = await run_recursive_dns(
+        result,
+        resolvers,
+        ('dev',),
+        RecursiveDNSLimits(depth=1, query_limit=100, runtime_seconds=5),
+    )
+
+    terminal = format_run_terminal(result)
+    records = [json.loads(line) for line in run_result_jsonl(result).splitlines()]
+    legacy = legacy_json_result(result)
+    xml = ElementTree.fromstring(evidence_xml_fragment(result))
+
+    assert 'dev.api.example.com [status=currently-addressable; sources=action:dns-recursive; ' in terminal
+    assert 'derivation=recursive-dns; parent=api.example.com]' in terminal
+    assert 'queries=12; depth=1; zero-yield=0; stop=depth-limit' in terminal
+    discovery = next(
+        record['data']
+        for record in records
+        if record['record_type'] == 'discovery_observation' and record['data']['value'] == 'dev.api.example.com'
+    )
+    assert discovery['derivation'] == 'recursive-dns'
+    assert discovery['parent'] == 'api.example.com'
+    assert legacy['evidence_run']['recursive_observations'] == [discovery]
+    xml_observation = xml.find("discovery_observation[@value='dev.api.example.com']")
+    assert xml_observation is not None
+    assert xml_observation.attrib['derivation'] == 'recursive-dns'
+    assert xml_observation.attrib['parent'] == 'api.example.com'
+    xml_source = xml.find("source[@name='action:dns-recursive']")
+    assert xml_source is not None
+    assert xml_source.attrib['query_count'] == '12'
+    assert result.to_dict()['source_executions'][-1]['stop_reason'] == 'depth-limit'
+
+
+@pytest.mark.asyncio
+async def test_cli_and_rest_select_recursive_dns_as_bounded_p1_activity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from theHarvester import __main__
+    from theHarvester.lib.api import api
+    from theHarvester.lib.source_catalog import describe_activity, resolve_sources
+
+    cli_args = __main__.build_parser().parse_args(
+        [
+            '-d',
+            'example.com',
+            '--dns-recursive-depth',
+            '2',
+            '--dns-recursive-query-limit',
+            '321',
+            '--dns-recursive-runtime-seconds',
+            '4.5',
+        ]
+    )
+    assert __main__.selected_actions(cli_args) == ('dns-recursive',)
+    assert describe_activity(resolve_sources(()), actions=__main__.selected_actions(cli_args)) == (
+        'Activity: P0 passive=disabled; P1 DNS=enabled; P2 direct=disabled.'
+    )
+
+    captured: Namespace | None = None
+
+    async def fake_start(args: Namespace, *, return_evidence_run: bool = False) -> tuple[object, ...]:
+        nonlocal captured
+        assert return_evidence_run is True
+        captured = args
+        return ([], [], [], [], [], [], [], [], [], None)
+
+    monkeypatch.setattr(api.__main__, 'start', fake_start)
+    response = await api.query.__wrapped__(
+        None,
+        [],
+        'example.com',
+        dns_recursive_depth=2,
+        dns_recursive_query_limit=321,
+        dns_recursive_runtime_seconds=4.5,
+    )
+
+    assert response.status_code == 200
+    assert captured is not None
+    assert __main__.selected_actions(captured) == ('dns-recursive',)
+    assert captured.dns_recursive_depth == cli_args.dns_recursive_depth == 2
+    assert captured.dns_recursive_query_limit == cli_args.dns_recursive_query_limit == 321
+    assert captured.dns_recursive_runtime_seconds == cli_args.dns_recursive_runtime_seconds == 4.5

--- a/tests/lib/test_source_catalog.py
+++ b/tests/lib/test_source_catalog.py
@@ -191,6 +191,7 @@ def test_existing_action_options_have_one_activity_class() -> None:
     assert ACTION_ACTIVITIES == {
         'dns-brute': ActivityClass.DNS,
         'dns-lookup': ActivityClass.DNS,
+        'dns-recursive': ActivityClass.DNS,
         'dns-resolve': ActivityClass.DNS,
         'shodan': ActivityClass.PASSIVE,
         'api-scan': ActivityClass.DIRECT,

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -92,6 +92,7 @@ from theHarvester.lib.output import (
 from theHarvester.lib.run import (
     AioDNSResolverVantage,
     LegacyHostnameSource,
+    RecursiveDNSLimits,
     SourceExecution,
     SourceRateLimitedError,
     SourceSkippedError,
@@ -104,6 +105,7 @@ from theHarvester.lib.run import (
     complete_run,
     execute_run,
     legacy_hostnames,
+    run_recursive_dns,
     validate_unvalidated_entities,
 )
 from theHarvester.lib.source_catalog import SourceSchedule, canonical_source_names, describe_activity, resolve_sources
@@ -205,6 +207,24 @@ def build_parser() -> argparse.ArgumentParser:
         action='store_true',
     )
     parser.add_argument(
+        '--dns-recursive-depth',
+        help='Recursively discover DNS names beneath confirmed parents to this many levels (P1 DNS interaction).',
+        default=0,
+        type=int,
+    )
+    parser.add_argument(
+        '--dns-recursive-query-limit',
+        help='Maximum resolver-vantage query attempts for recursive DNS discovery.',
+        default=10_000,
+        type=int,
+    )
+    parser.add_argument(
+        '--dns-recursive-runtime-seconds',
+        help='Maximum runtime in seconds for recursive DNS discovery.',
+        default=60.0,
+        type=float,
+    )
+    parser.add_argument(
         '-f',
         '--filename',
         help='Save the results to an XML and JSON file.',
@@ -235,6 +255,7 @@ def selected_actions(args: argparse.Namespace) -> tuple[str, ...]:
         for name, enabled in (
             ('dns-brute', getattr(args, 'dns_brute', False)),
             ('dns-lookup', getattr(args, 'dns_lookup', False)),
+            ('dns-recursive', getattr(args, 'dns_recursive_depth', 0) > 0),
             ('dns-resolve', dns_resolve is None or bool(dns_resolve)),
             ('shodan', getattr(args, 'shodan', False)),
             ('api-scan', getattr(args, 'api_scan', False)),
@@ -353,6 +374,28 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
             raise resolver_error
         print(f'\n[!] {resolver_error}.\n')
         sys.exit(1)
+    recursive_limits = None
+    recursive_depth = getattr(args, 'dns_recursive_depth', 0)
+    if recursive_depth < 0:
+        depth_error = ValueError('--dns-recursive-depth cannot be negative')
+        if rest_args is not None:
+            raise depth_error
+        print(f'\n[!] {depth_error}.\n')
+        sys.exit(1)
+    if recursive_depth > 0:
+        try:
+            recursive_limits = RecursiveDNSLimits(
+                depth=recursive_depth,
+                query_limit=getattr(args, 'dns_recursive_query_limit', 10_000),
+                runtime_seconds=getattr(args, 'dns_recursive_runtime_seconds', 60.0),
+            )
+            if len(final_dns_resolver_list) != 3:
+                raise ValueError('--dns-recursive-depth requires --dns-resolve with exactly three resolver vantages')
+        except ValueError as error:
+            if rest_args is not None:
+                raise
+            print(f'\n[!] {error}.\n')
+            sys.exit(1)
 
     engines: list = []
     # If the user specifies
@@ -2030,6 +2073,8 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
 
     recorded_stages = {result.source.casefold() for result in stage_results}
     for action in selected_actions(args):
+        if action == 'dns-recursive':
+            continue
         stage_source = f'action:{action}'
         if stage_source.casefold() not in recorded_stages:
             stage_results.append(
@@ -2055,6 +2100,34 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                     completed_run_result,
                     resolver_vantages,
                 )
+                if recursive_limits is not None:
+                    recursive_started = time.perf_counter()
+                    try:
+                        completed_run_result = await run_recursive_dns(
+                            completed_run_result,
+                            resolver_vantages,
+                            dnssearch.DNS_NAMES.read_text(encoding='utf-8').splitlines(),
+                            recursive_limits,
+                        )
+                    except Exception as error:
+                        completed_run_result = replace(
+                            completed_run_result,
+                            source_executions=(
+                                *completed_run_result.source_executions,
+                                SourceExecution(
+                                    run_id=completed_run_result.run_id,
+                                    source='action:dns-recursive',
+                                    source_family='dns-recursive',
+                                    status=SourceStatus.FAILED,
+                                    duration_ms=(time.perf_counter() - recursive_started) * 1000,
+                                    result_count=0,
+                                    observation_count=0,
+                                    entity_count=0,
+                                    error_type=type(error).__name__,
+                                ),
+                            ),
+                        )
+                        print(f'[!] Recursive DNS discovery failed: {error}')
         except Exception as error:
             completed_run_result = replace(
                 completed_run_result,
@@ -2069,6 +2142,24 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                     for execution in completed_run_result.source_executions
                 ),
             )
+            if recursive_limits is not None:
+                completed_run_result = replace(
+                    completed_run_result,
+                    source_executions=(
+                        *completed_run_result.source_executions,
+                        SourceExecution(
+                            run_id=completed_run_result.run_id,
+                            source='action:dns-recursive',
+                            source_family='dns-recursive',
+                            status=SourceStatus.SKIPPED,
+                            duration_ms=0,
+                            result_count=0,
+                            observation_count=0,
+                            entity_count=0,
+                            error_type='DNSValidationFailed',
+                        ),
+                    ),
+                )
             print(f'[!] DNS validation failed: {error}')
     await SQLiteRunStore().save(completed_run_result)
     print(format_run_terminal(completed_run_result))

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -300,6 +300,15 @@ async def query(
     dns_resolve: Annotated[
         str, Query(description='Perform DNS resolution on subdomains with a resolver list or passed in resolvers')
     ] = '',
+    dns_recursive_depth: Annotated[
+        int, Query(ge=0, description='Recursively discover DNS names beneath confirmed parents to this many levels')
+    ] = 0,
+    dns_recursive_query_limit: Annotated[
+        int, Query(gt=0, description='Maximum resolver-vantage query attempts for recursive DNS discovery')
+    ] = 10_000,
+    dns_recursive_runtime_seconds: Annotated[
+        float, Query(gt=0, description='Maximum runtime in seconds for recursive DNS discovery')
+    ] = 60.0,
     filename: Annotated[str, Query(description='Save the results to an XML and JSON file')] = '',
     proxies: Annotated[bool, Query(description='Use proxies for requests')] = False,
     shodan: Annotated[bool, Query(description='Use Shodan to query discovered hosts')] = False,
@@ -362,6 +371,9 @@ async def query(
                 wordlist=wordlist,
                 api_scan=api_scan,
                 dns_resolve=dns_resolve,
+                dns_recursive_depth=dns_recursive_depth,
+                dns_recursive_query_limit=dns_recursive_query_limit,
+                dns_recursive_runtime_seconds=dns_recursive_runtime_seconds,
                 quiet=False,
                 screenshot='',
             ),

--- a/theHarvester/lib/output.py
+++ b/theHarvester/lib/output.py
@@ -49,7 +49,12 @@ def print_linkedin_sections(
 def _entity_line(entity: MergedEntity, selected: Sequence[SelectedObservation] = ()) -> str:
     sources = ','.join(sorted({observation.source for observation in entity.observations}))
     selected_status = ''.join(f'; {observation.kind}={observation.detail or "observed"}' for observation in selected)
-    return f'{entity.value} [status={entity.addressability}; sources={sources}{selected_status}]'
+    recursive = next(
+        (observation for observation in entity.observations if observation.parent is not None),
+        None,
+    )
+    recursive_status = f'; derivation={recursive.derivation}; parent={recursive.parent}' if recursive is not None else ''
+    return f'{entity.value} [status={entity.addressability}; sources={sources}{selected_status}{recursive_status}]'
 
 
 def format_run_terminal(result: RunResult) -> str:
@@ -99,7 +104,14 @@ def format_run_terminal(result: RunResult) -> str:
         '[*] Source executions',
         *(
             f'{execution.source} [status={execution.status}; results={execution.result_count}; '
-            f'observations={execution.observation_count}]'
+            f'observations={execution.observation_count}'
+            + (
+                f'; queries={execution.query_count}; depth={execution.depth_reached}; '
+                f'zero-yield={execution.zero_yield_batches}; stop={execution.stop_reason}'
+                if execution.query_count is not None
+                else ''
+            )
+            + ']'
             for execution in result.source_executions
         ),
     ]
@@ -141,11 +153,15 @@ def _jsonl_entity(entity: MergedEntity) -> dict[str, object]:
 
 
 def _evidence_summary(result: RunResult) -> dict[str, object]:
-    return {
+    summary = {
         **_run_record(result),
         'source_executions': [execution.to_dict() for execution in result.source_executions],
         'selected_observations': [observation.to_dict() for observation in result.selected_observations],
     }
+    recursive_observations = [observation.to_dict() for observation in result.observations if observation.parent is not None]
+    if recursive_observations:
+        summary['recursive_observations'] = recursive_observations
+    return summary
 
 
 def _run_record(result: RunResult) -> dict[str, object]:
@@ -174,15 +190,39 @@ def evidence_xml_fragment(result: RunResult) -> str:
 def _evidence_xml_element(result: RunResult) -> Element:
     evidence_run = Element('evidence_run', run_id=result.run_id, status=result.status)
     for execution in result.source_executions:
-        SubElement(evidence_run, 'source', name=execution.source, status=execution.status)
-    for observation in result.selected_observations:
+        attributes = {'name': execution.source, 'status': execution.status}
+        if execution.query_count is not None:
+            attributes.update(
+                {
+                    'query_count': str(execution.query_count),
+                    'depth_reached': str(execution.depth_reached),
+                    'zero_yield_batches': str(execution.zero_yield_batches),
+                    'stop_reason': execution.stop_reason or '',
+                }
+            )
+        SubElement(evidence_run, 'source', attributes)
+    for recursive_observation in result.observations:
+        if recursive_observation.parent is None:
+            continue
+        SubElement(
+            evidence_run,
+            'discovery_observation',
+            {
+                'source': recursive_observation.source,
+                'value': recursive_observation.value,
+                'derivation': recursive_observation.derivation,
+                'parent': recursive_observation.parent,
+                'collected_at': recursive_observation.collected_at.isoformat(),
+            },
+        )
+    for selected_observation in result.selected_observations:
         attributes = {
-            'source': observation.source,
-            'kind': observation.kind,
-            'value': observation.value,
-            'collected_at': observation.collected_at.isoformat(),
+            'source': selected_observation.source,
+            'kind': selected_observation.kind,
+            'value': selected_observation.value,
+            'collected_at': selected_observation.collected_at.isoformat(),
         }
-        if observation.detail is not None:
-            attributes['detail'] = observation.detail
+        if selected_observation.detail is not None:
+            attributes['detail'] = selected_observation.detail
         SubElement(evidence_run, 'selected_observation', attributes)
     return evidence_run

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -22,6 +22,7 @@ class Derivation(StrEnum):
     PROVIDER = 'provider'
     RELATED = 'related'
     EXTERNAL_RELATIONSHIP = 'external-relationship'
+    RECURSIVE_DNS = 'recursive-dns'
 
 
 class ScopeClass(StrEnum):
@@ -50,6 +51,21 @@ class RunStatus(StrEnum):
     COMPLETE = 'complete'
     PARTIAL = 'partial'
     FAILED = 'failed'
+
+
+@dataclass(frozen=True, slots=True)
+class RecursiveDNSLimits:
+    depth: int
+    query_limit: int
+    runtime_seconds: float
+
+    def __post_init__(self) -> None:
+        if self.depth <= 0:
+            raise ValueError('recursive DNS depth must be greater than zero')
+        if self.query_limit <= 0:
+            raise ValueError('recursive DNS query limit must be greater than zero')
+        if self.runtime_seconds <= 0:
+            raise ValueError('recursive DNS runtime must be greater than zero')
 
 
 class SourceRateLimitedError(Exception):
@@ -264,6 +280,7 @@ class DiscoveryObservation:
     collected_at: datetime
     scope_class: ScopeClass
     provider_observed_at: datetime | None = None
+    parent: str | None = None
 
     def to_dict(self) -> dict[str, str]:
         result = {
@@ -278,6 +295,8 @@ class DiscoveryObservation:
         }
         if self.provider_observed_at is not None:
             result['provider_observed_at'] = self.provider_observed_at.isoformat()
+        if self.parent is not None:
+            result['parent'] = self.parent
         return result
 
 
@@ -330,9 +349,13 @@ class SourceExecution:
     observation_count: int
     entity_count: int
     error_type: str | None = None
+    query_count: int | None = None
+    depth_reached: int | None = None
+    zero_yield_batches: int | None = None
+    stop_reason: str | None = None
 
     def to_dict(self) -> dict[str, str | float | int | None]:
-        return {
+        result: dict[str, str | float | int | None] = {
             'run_id': self.run_id,
             'source': self.source,
             'source_family': self.source_family,
@@ -343,6 +366,15 @@ class SourceExecution:
             'entity_count': self.entity_count,
             'error_type': self.error_type,
         }
+        if self.query_count is not None:
+            result['query_count'] = self.query_count
+        if self.depth_reached is not None:
+            result['depth_reached'] = self.depth_reached
+        if self.zero_yield_batches is not None:
+            result['zero_yield_batches'] = self.zero_yield_batches
+        if self.stop_reason is not None:
+            result['stop_reason'] = self.stop_reason
+        return result
 
 
 @dataclass(frozen=True)
@@ -483,6 +515,8 @@ _RESOLVER_VANTAGE_COUNT = 3
 _RESOLVER_QUORUM = 2
 _WILDCARD_PROBES_PER_DEPTH = 3
 _MAX_CNAME_DEPTH = 16
+_RECURSIVE_BATCH_SIZE = 50
+_MAX_ZERO_YIELD_BATCHES = 3
 
 
 def _normalize_dns_response(response: DNSResponse) -> DNSResponse:
@@ -821,4 +855,216 @@ async def validate_unvalidated_entities(
         completed_at=datetime.now(UTC),
         dns_validations=(*result.dns_validations, *validations),
         entities=tuple(validated_by_value.get(entity.value, entity) for entity in result.entities),
+    )
+
+
+async def run_recursive_dns(
+    result: RunResult,
+    resolver_vantages: Sequence[ResolverVantage],
+    labels: Sequence[str],
+    limits: RecursiveDNSLimits,
+) -> RunResult:
+    """Expand confirmed in-scope parents with bounded breadth-first DNS discovery."""
+    if (
+        len(resolver_vantages) != _RESOLVER_VANTAGE_COUNT
+        or len({resolver.name for resolver in resolver_vantages}) != _RESOLVER_VANTAGE_COUNT
+    ):
+        raise ValueError('recursive DNS discovery requires exactly three distinct resolver vantages')
+
+    started = time.perf_counter()
+    deadline = started + limits.runtime_seconds
+    normalized_labels: list[str] = []
+    for value in labels:
+        if time.perf_counter() >= deadline:
+            break
+        try:
+            label = _normalize_hostname(value)
+        except (UnicodeError, ValueError):
+            continue
+        if (
+            '.' in label
+            or len(label) > 63
+            or label.startswith('-')
+            or label.endswith('-')
+            or not all(character.isascii() and (character.isalnum() or character in {'-', '_'}) for character in label)
+        ):
+            continue
+        normalized_labels.append(label)
+    candidate_labels = tuple(dict.fromkeys(normalized_labels))
+    frontier = sorted(
+        entity.value
+        for entity in result.entities
+        if ScopeClass.IN_SCOPE in entity.scope_classes and entity.addressability is Addressability.CURRENT
+    )
+    seen = {entity.value for entity in result.entities}
+    observations = list(result.observations)
+    validations = list(result.dns_validations)
+    entities = list(result.entities)
+    query_count = 0
+    completed_depth = 0
+    total_zero_yield_batches = 0
+    consecutive_zero_yield_batches = 0
+    currently_addressable_count = 0
+    stopped = time.perf_counter() >= deadline
+    stop_reason = 'runtime-limit' if stopped else 'frontier-exhausted'
+
+    for depth in range(1, 1 if stopped else limits.depth + 1):
+        next_frontier: list[str] = []
+        for parent in frontier:
+            parent_candidates = []
+            for label in candidate_labels:
+                if time.perf_counter() >= deadline:
+                    stop_reason = 'runtime-limit'
+                    stopped = True
+                    break
+                candidate = f'{label}.{parent}'
+                if candidate in seen:
+                    continue
+                seen.add(candidate)
+                if _classify_scope(result.target, candidate, Derivation.RECURSIVE_DNS) is ScopeClass.IN_SCOPE:
+                    parent_candidates.append(candidate)
+            if stopped:
+                break
+            if not parent_candidates:
+                continue
+            if limits.query_limit - query_count < 12:
+                stop_reason = 'query-limit'
+                stopped = True
+                break
+            remaining = deadline - time.perf_counter()
+            if remaining <= 0:
+                stop_reason = 'runtime-limit'
+                stopped = True
+                break
+
+            control_queries = tuple(f'th-{uuid4().hex}.{parent}' for _ in range(_WILDCARD_PROBES_PER_DEPTH))
+            query_count += len(control_queries) * len(resolver_vantages)
+            try:
+                async with asyncio.timeout(remaining):
+                    controls = tuple(
+                        await asyncio.gather(
+                            *(
+                                _query_dns(
+                                    result.run_id,
+                                    parent,
+                                    query_name,
+                                    resolver,
+                                    wildcard_depth=parent,
+                                )
+                                for query_name in control_queries
+                                for resolver in resolver_vantages
+                            )
+                        )
+                    )
+            except TimeoutError:
+                stop_reason = 'runtime-limit'
+                stopped = True
+                break
+            validations.extend(controls)
+
+            for offset in range(0, len(parent_candidates), _RECURSIVE_BATCH_SIZE):
+                remaining_queries = limits.query_limit - query_count
+                batch_size = min(_RECURSIVE_BATCH_SIZE, remaining_queries // len(resolver_vantages))
+                if batch_size <= 0:
+                    stop_reason = 'query-limit'
+                    stopped = True
+                    break
+                batch = parent_candidates[offset : offset + batch_size]
+                remaining = deadline - time.perf_counter()
+                if remaining <= 0:
+                    stop_reason = 'runtime-limit'
+                    stopped = True
+                    break
+                query_count += len(batch) * len(resolver_vantages)
+                try:
+                    async with asyncio.timeout(remaining):
+                        answers = tuple(
+                            await asyncio.gather(
+                                *(
+                                    _query_dns(result.run_id, candidate, candidate, resolver)
+                                    for candidate in batch
+                                    for resolver in resolver_vantages
+                                )
+                            )
+                        )
+                except TimeoutError:
+                    stop_reason = 'runtime-limit'
+                    stopped = True
+                    break
+
+                collected_at = datetime.now(UTC)
+                batch_yield = 0
+                for index, candidate in enumerate(batch):
+                    candidate_validations = answers[index * len(resolver_vantages) : (index + 1) * len(resolver_vantages)]
+                    validations.extend(candidate_validations)
+                    observation = DiscoveryObservation(
+                        run_id=result.run_id,
+                        target=result.target,
+                        value=candidate,
+                        source='action:dns-recursive',
+                        source_family='dns-recursive',
+                        derivation=Derivation.RECURSIVE_DNS,
+                        collected_at=collected_at,
+                        scope_class=ScopeClass.IN_SCOPE,
+                        parent=parent,
+                    )
+                    addressability = _classify_addressability(candidate_validations, controls)
+                    observations.append(observation)
+                    entities.append(
+                        MergedEntity(
+                            candidate,
+                            (observation,),
+                            addressability,
+                            (*candidate_validations, *controls),
+                        )
+                    )
+                    if addressability is Addressability.CURRENT:
+                        next_frontier.append(candidate)
+                        currently_addressable_count += 1
+                        batch_yield += 1
+
+                if batch_yield:
+                    consecutive_zero_yield_batches = 0
+                else:
+                    consecutive_zero_yield_batches += 1
+                    total_zero_yield_batches += 1
+                    if consecutive_zero_yield_batches >= _MAX_ZERO_YIELD_BATCHES:
+                        stop_reason = 'zero-yield'
+                        stopped = True
+                        break
+            if stopped:
+                break
+        if stopped:
+            break
+        completed_depth = depth
+        frontier = sorted(next_frontier)
+        if not frontier:
+            stop_reason = 'frontier-exhausted'
+            break
+    else:
+        if not stopped:
+            stop_reason = 'depth-limit'
+
+    duration_ms = (time.perf_counter() - started) * 1000
+    execution = SourceExecution(
+        run_id=result.run_id,
+        source='action:dns-recursive',
+        source_family='dns-recursive',
+        status=SourceStatus.SUCCEEDED if currently_addressable_count else SourceStatus.EMPTY,
+        duration_ms=duration_ms,
+        result_count=currently_addressable_count,
+        observation_count=len(observations) - len(result.observations),
+        entity_count=len(entities) - len(result.entities),
+        query_count=query_count,
+        depth_reached=completed_depth,
+        zero_yield_batches=total_zero_yield_batches,
+        stop_reason=stop_reason,
+    )
+    return replace(
+        result,
+        completed_at=datetime.now(UTC),
+        source_executions=(*result.source_executions, execution),
+        observations=tuple(observations),
+        dns_validations=tuple(validations),
+        entities=tuple(entities),
     )

--- a/theHarvester/lib/source_catalog.py
+++ b/theHarvester/lib/source_catalog.py
@@ -19,6 +19,7 @@ class ActivityClass(StrEnum):
 ACTION_ACTIVITIES: Final = {
     'dns-brute': ActivityClass.DNS,
     'dns-lookup': ActivityClass.DNS,
+    'dns-recursive': ActivityClass.DNS,
     'dns-resolve': ActivityClass.DNS,
     'shodan': ActivityClass.PASSIVE,
     'api-scan': ActivityClass.DIRECT,


### PR DESCRIPTION
## Summary

- add bounded recursive DNS discovery
- derive follow-up candidates from evidence-bearing results
- expose the bounded activity consistently through CLI, REST, output, and source metadata

## Stack

Depends on `codex/completed-run-output`. Review only this PR's one-commit delta.

## Validation

`uv run pytest tests/lib/test_recursive_dns.py tests/lib/test_source_catalog.py`

Result: 24 passed.

