### PR TITLE
Report one completed evidence run

### DIFF
--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -140,6 +140,16 @@ async def test_one_completed_run_drives_every_output_surface_without_losing_lega
         'selected_observation',
     }
     assert all(record['schema_version'] == 'theharvester-evidence-v1' for record in records)
+    assert all(record['run_id'] == result.run_id for record in records)
+    assert all(record['target'] == 'example.com' for record in records)
+    run_record = next(record['data'] for record in records if record['record_type'] == 'run')
+    assert run_record['record_counts'] == {
+        'source_executions': sum(record['record_type'] == 'source_execution' for record in records),
+        'discovery_observations': sum(record['record_type'] == 'discovery_observation' for record in records),
+        'dns_validation_observations': sum(record['record_type'] == 'dns_validation_observation' for record in records),
+        'merged_results': sum(record['record_type'] == 'merged_result' for record in records),
+        'selected_observations': sum(record['record_type'] == 'selected_observation' for record in records),
+    }
     discovery_records = [record['data'] for record in records if record['record_type'] == 'discovery_observation']
     assert all(record['collected_at'] for record in discovery_records)
     assert discovery_records[0]['provider_observed_at'] == '2026-07-15T12:00:00+00:00'
@@ -165,6 +175,12 @@ async def test_one_completed_run_drives_every_output_surface_without_losing_lega
     assert rest['hosts'] == ['api.example.com']
     assert rest['evidence_run']['run_id'] == result.run_id
     assert await store.load(result.run_id) == result.to_dict()
+
+
+def test_filename_help_names_every_report_format() -> None:
+    from theHarvester.__main__ import build_parser
+
+    assert 'Save XML, legacy JSON, and normalized JSONL reports.' in build_parser().format_help()
 
 
 @pytest.mark.parametrize(

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -183,6 +183,164 @@ def test_filename_help_names_every_report_format() -> None:
     assert 'Save XML, legacy JSON, and normalized JSONL reports.' in build_parser().format_help()
 
 
+@pytest.mark.asyncio
+async def test_cli_collector_curates_people_and_preserves_shodan_attributes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import theHarvester.__main__ as main_module
+
+    person = {
+        'email': 'ada@example.com',
+        'firstname': 'Ada',
+        'lastname': 'Lovelace',
+        'company': 'Example Corp',
+        'city': 'London',
+        'phone': '+1-555-0100',
+        'address': 'sensitive address',
+        'zip_code': '12345',
+        'dob': '1815-12-10',
+        'password': 'must-not-appear',
+    }
+    sensitive_only_person = {
+        'phone': '+1-555-0199',
+        'address': 'another sensitive address',
+        'dob': '1900-01-01',
+    }
+    named_person = {'firstname': 'Grace', 'lastname': 'Hopper'}
+    role_only_person = {'role': 'researcher'}
+    shodan_attributes = {
+        'asn': 'AS64500',
+        'domains': ['example.com'],
+        'hostnames': ['api.example.com'],
+        'ip_str': '192.0.2.10',
+        'isp': 'Example ISP',
+        'org': 'Example Corp',
+        'ports': [443],
+        'product': 'nginx',
+        'server': 'nginx',
+        'technologies': ['nginx'],
+        'title': 'Example',
+    }
+
+    class FakeVenacusSearch:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+        async def process(self, _proxy: bool = False) -> None:
+            return None
+
+        async def get_people(self) -> list[dict[str, str]]:
+            return [person, named_person, role_only_person, sensitive_only_person]
+
+        async def get_emails(self) -> set[str]:
+            return {'ada@example.com'}
+
+        async def get_ips(self) -> set[str]:
+            return {'192.0.2.10'}
+
+        async def get_interestingurls(self) -> set[str]:
+            return set()
+
+    class FakeShodanSearch:
+        def __init__(self) -> None:
+            return None
+
+        async def search_ip(self, ip: str) -> dict[str, object]:
+            return {ip: shodan_attributes}
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args: object) -> None:
+            return None
+
+    class FakeRunStore:
+        async def save(self, _result: RunResult) -> None:
+            return None
+
+    async def no_sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(main_module.venacussearch, 'SearchVenacus', FakeVenacusSearch)
+    monkeypatch.setattr(main_module.shodansearch, 'SearchShodan', FakeShodanSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore)
+    monkeypatch.setattr(main_module.asyncio, 'sleep', no_sleep)
+
+    response = await main_module.start(
+        SimpleNamespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=True,
+            screenshot='',
+            shodan=True,
+            source='venacus',
+            start=0,
+            take_over=False,
+            wordlist='',
+        ),
+        return_evidence_run=True,
+    )
+
+    result = response[-1]
+    jsonl = run_result_jsonl(result)
+    records = [json.loads(line) for line in jsonl.splitlines()]
+    selected = [
+        record['data']
+        for record in records
+        if record['record_type'] == 'selected_observation' and record['data']['kind'] in {'person', 'shodan-result'}
+    ]
+    people_records = [record for record in selected if record['kind'] == 'person']
+    shodan_record = next(record for record in selected if record['kind'] == 'shodan-result')
+
+    assert [(record['value'], record['attributes']) for record in people_records] == [
+        (
+            'ada@example.com',
+            {
+                'email': 'ada@example.com',
+                'firstname': 'Ada',
+                'lastname': 'Lovelace',
+                'company': 'Example Corp',
+                'city': 'London',
+            },
+        ),
+        ('Grace Hopper', named_person),
+        ('person-15cd96492d3a', role_only_person),
+    ]
+    assert 'must-not-appear' not in jsonl
+    assert '+1-555-' not in jsonl
+    assert 'sensitive address' not in jsonl
+    assert shodan_record['value'] == '192.0.2.10'
+    assert shodan_record['detail'] is None
+    assert shodan_record['attributes'] == shodan_attributes
+    legacy_people = [{'name': 'existing person'}]
+    legacy_shodan = [['existing shodan row']]
+    legacy = legacy_json_result(result, {'people': legacy_people, 'shodan': legacy_shodan})
+    evidence_xml = ElementTree.fromstring(evidence_xml_fragment(result))
+
+    assert legacy['people'] == legacy_people
+    assert legacy['shodan'] == legacy_shodan
+    assert evidence_xml.tag == 'evidence_run'
+    assert [
+        (item.attrib['kind'], item.attrib['value'], item.attrib.get('detail'))
+        for item in evidence_xml.findall('selected_observation')
+        if item.attrib['kind'] in {'person', 'shodan-result'}
+    ] == [
+        ('person', 'ada@example.com', None),
+        ('person', 'Grace Hopper', None),
+        ('person', 'person-15cd96492d3a', None),
+        ('shodan-result', '192.0.2.10', None),
+    ]
+
+
 @pytest.mark.parametrize(
     ('error', 'expected_run_status', 'expected_source_status'),
     [

--- a/tests/lib/test_completed_output.py
+++ b/tests/lib/test_completed_output.py
@@ -1,0 +1,571 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, ClassVar
+from xml.etree import ElementTree
+
+import pytest
+
+from theHarvester.lib.output import (
+    evidence_xml_fragment,
+    format_run_terminal,
+    legacy_json_result,
+    run_result_jsonl,
+)
+from theHarvester.lib.run import (
+    Derivation,
+    DNSResponse,
+    RunResult,
+    SourceFinding,
+    SourceRateLimitedError,
+    SourceStatus,
+    SQLiteRunStore,
+    StageFinding,
+    StageFindingKind,
+    StageResult,
+    complete_run,
+    execute_run,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class CompletedRunSource:
+    name = 'fixture'
+    family = 'fixture-family'
+
+    async def collect(self, _target: str) -> list[SourceFinding]:
+        return [
+            SourceFinding(
+                'api.example.com',
+                observed_at=datetime(2026, 7, 15, 12, tzinfo=UTC),
+            ),
+            SourceFinding('old.example.com'),
+            SourceFinding('related.example.net', Derivation.RELATED),
+            SourceFinding('cdn.vendor.test', Derivation.EXTERNAL_RELATIONSHIP),
+            SourceFinding('mixed.example.net', Derivation.RELATED),
+            SourceFinding('mixed.example.net', Derivation.EXTERNAL_RELATIONSHIP),
+        ]
+
+
+class CompletedRunResolver:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    async def query(self, hostname: str) -> DNSResponse:
+        if hostname == 'api.example.com':
+            return DNSResponse(ipv4=('192.0.2.10',), ttl=60)
+        return DNSResponse(rcode='NXDOMAIN')
+
+
+class IncompleteRunSource:
+    name = 'fixture'
+    family = 'fixture-family'
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    async def collect(self, _target: str) -> list[SourceFinding]:
+        raise self.error
+
+
+@pytest.mark.asyncio
+async def test_one_completed_run_drives_every_output_surface_without_losing_legacy_fields(
+    tmp_path: Path,
+) -> None:
+    store = SQLiteRunStore(tmp_path / 'evidence.sqlite')
+    result = await execute_run(
+        'example.com',
+        CompletedRunSource(),
+        resolver_vantages=tuple(CompletedRunResolver(f'resolver-{index}') for index in range(3)),
+        persist=False,
+    )
+    result = complete_run(
+        result,
+        (
+            StageResult(
+                'action:dns-brute',
+                SourceStatus.SUCCEEDED,
+                1,
+                1,
+                (StageFinding(StageFindingKind.HOSTNAME, 'late.example.com:192.0.2.11'),),
+            ),
+            StageResult(
+                'action:take-over',
+                SourceStatus.SUCCEEDED,
+                1,
+                1,
+                (StageFinding(StageFindingKind.TAKEOVER, 'api.example.com', 'not vulnerable'),),
+            ),
+            StageResult(
+                'action:api-scan',
+                SourceStatus.SUCCEEDED,
+                1,
+                1,
+                (StageFinding(StageFindingKind.API_ENDPOINT, '/v1/status', '200'),),
+            ),
+        ),
+    )
+    await store.save(result)
+
+    terminal = format_run_terminal(result)
+    records = [json.loads(line) for line in run_result_jsonl(result).splitlines()]
+    legacy_json = legacy_json_result(result, {'cmd': 'theHarvester -d example.com', 'emails': ['ops@example.com']})
+    evidence_xml = ElementTree.fromstring(evidence_xml_fragment(result))
+    rest = legacy_json_result(result, {'emails': ['ops@example.com']})
+
+    assert terminal.count('api.example.com') == 1
+    assert terminal.count('old.example.com') == 1
+    assert terminal.count('related.example.net') == 1
+    assert terminal.count('cdn.vendor.test') == 1
+    assert terminal.count('mixed.example.net') == 1
+    assert terminal.count('late.example.com') == 1
+    assert 'takeover=not vulnerable' in terminal
+    assert '/v1/status [api-endpoint=200; source=action:api-scan]' in terminal
+    assert 'Currently addressable subdomains (1)' in terminal
+    assert 'Secondary evidence / needs review (4)' in terminal
+    assert 'Scope-extension candidates (1)' in terminal
+    assert 'status=currently-addressable; sources=fixture' in terminal
+    assert 'Run status: complete' in terminal
+
+    assert {record['record_type'] for record in records} == {
+        'run',
+        'source_execution',
+        'discovery_observation',
+        'dns_validation_observation',
+        'merged_result',
+        'selected_observation',
+    }
+    assert all(record['schema_version'] == 'theharvester-evidence-v1' for record in records)
+    discovery_records = [record['data'] for record in records if record['record_type'] == 'discovery_observation']
+    assert all(record['collected_at'] for record in discovery_records)
+    assert discovery_records[0]['provider_observed_at'] == '2026-07-15T12:00:00+00:00'
+    assert 'provider_observed_at' not in discovery_records[1]
+    validation_records = [record['data'] for record in records if record['record_type'] == 'dns_validation_observation']
+    assert all(record['validated_at'] for record in validation_records)
+
+    assert legacy_json['cmd'] == 'theHarvester -d example.com'
+    assert legacy_json['emails'] == ['ops@example.com']
+    assert legacy_json['hosts'] == ['api.example.com']
+    assert legacy_json['evidence_run']['status'] == 'complete'
+    selected_records = [record['data'] for record in records if record['record_type'] == 'selected_observation']
+    assert {(record['kind'], record['value'], record['detail']) for record in selected_records} == {
+        ('takeover', 'api.example.com', 'not vulnerable'),
+        ('api-endpoint', '/v1/status', '200'),
+    }
+    assert evidence_xml.attrib['status'] == 'complete'
+    assert {item.attrib['kind'] for item in evidence_xml.findall('selected_observation')} == {
+        'takeover',
+        'api-endpoint',
+    }
+    assert rest['emails'] == ['ops@example.com']
+    assert rest['hosts'] == ['api.example.com']
+    assert rest['evidence_run']['run_id'] == result.run_id
+    assert await store.load(result.run_id) == result.to_dict()
+
+
+@pytest.mark.parametrize(
+    ('error', 'expected_run_status', 'expected_source_status'),
+    [
+        (RuntimeError('provider failed'), 'failed', 'failed'),
+        (SourceRateLimitedError(), 'partial', 'rate-limited'),
+    ],
+)
+@pytest.mark.asyncio
+async def test_incomplete_source_states_are_visible_on_every_completed_output(
+    tmp_path: Path,
+    error: Exception,
+    expected_run_status: str,
+    expected_source_status: str,
+) -> None:
+    result = await execute_run(
+        'example.com',
+        IncompleteRunSource(error),
+        store=SQLiteRunStore(tmp_path / f'{expected_source_status}.sqlite'),
+    )
+
+    terminal = format_run_terminal(result)
+    records = [json.loads(line) for line in run_result_jsonl(result).splitlines()]
+
+    assert f'Run status: {expected_run_status}' in terminal
+    assert f'fixture [status={expected_source_status}' in terminal
+    assert records[0]['data']['status'] == expected_run_status
+    assert legacy_json_result(result)['evidence_run']['status'] == expected_run_status
+    assert legacy_json_result(result)['evidence_run']['source_executions'][0]['status'] == expected_source_status
+    assert ElementTree.fromstring(evidence_xml_fragment(result)).attrib['status'] == expected_run_status
+
+
+@pytest.mark.asyncio
+async def test_empty_and_failed_selected_stages_remain_visible() -> None:
+    result = await execute_run('example.com', CompletedRunSource(), persist=False)
+    result = complete_run(
+        result,
+        (
+            StageResult('action:api-scan', SourceStatus.EMPTY, 2, 0),
+            StageResult(
+                'action:take-over',
+                SourceStatus.FAILED,
+                3,
+                0,
+                error_type='RuntimeError',
+            ),
+        ),
+    )
+
+    executions = {execution.source: execution for execution in result.source_executions}
+    assert executions['action:api-scan'].status is SourceStatus.EMPTY
+    assert executions['action:take-over'].status is SourceStatus.FAILED
+    assert result.status == 'partial'
+    assert 'action:take-over [status=failed' in format_run_terminal(result)
+
+
+@pytest.mark.asyncio
+async def test_cli_adapts_and_persists_the_run_only_after_selected_direct_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import theHarvester.__main__ as main_module
+    import theHarvester.lib.output as output_module
+    import theHarvester.lib.run as run_module
+
+    events: list[str] = []
+
+    class FakeParser:
+        def parse_args(self):
+            return SimpleNamespace(
+                api_scan=True,
+                dns_brute=True,
+                dns_lookup=True,
+                dns_resolve='192.0.2.53,192.0.2.54,192.0.2.55',
+                dns_server=None,
+                domain='example.com',
+                filename=str(tmp_path / 'completed-run'),
+                limit=500,
+                proxies=False,
+                quiet=False,
+                screenshot='',
+                shodan=False,
+                source='crtsh',
+                start=0,
+                take_over=True,
+                wordlist='',
+            )
+
+    class FakeCrtshSearch:
+        def __init__(self, _target: str) -> None:
+            return None
+
+        async def process(self, _proxy: bool = False) -> None:
+            events.append('collect')
+
+        async def get_hostnames(self) -> list[str]:
+            return ['api.example.com']
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args) -> None:
+            return None
+
+        async def store(self, *_args) -> None:
+            return None
+
+    class FakeRunStore:
+        saved: ClassVar[list[RunResult]] = []
+
+        async def save(self, _result) -> None:
+            events.append('persist')
+            self.saved.append(_result)
+
+    class FakeHostChecker:
+        def __init__(self, _hosts: list[str], _nameservers: list[str]) -> None:
+            return None
+
+        async def check(self):
+            return ['api.example.com:192.0.2.10'], ['api.example.com'], ['192.0.2.10']
+
+    class FakeResolver:
+        def __init__(self, nameserver: str) -> None:
+            self.name = nameserver
+
+        async def query(self, hostname: str) -> DNSResponse:
+            if hostname == 'api.example.com':
+                return DNSResponse(ipv4=('192.0.2.10',))
+            return DNSResponse(rcode='NXDOMAIN')
+
+        async def close(self) -> None:
+            return None
+
+    class FakeDnsForce:
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def run(self):
+            events.append('dns-brute')
+            return (
+                ['late.example.com:192.0.2.11', 'late.example.com:192.0.2.11'],
+                ['late.example.com'],
+                ['192.0.2.11'],
+            )
+
+    class FakeTakeOver:
+        def __init__(self, _hosts: list[str]) -> None:
+            return None
+
+        async def populate_fingerprints(self) -> None:
+            return None
+
+        async def process(self, *, proxy: bool) -> None:
+            assert proxy is False
+            events.append('direct')
+
+        async def get_takeover_results(self) -> dict[str, str]:
+            return {'api.example.com': 'not vulnerable'}
+
+    async def fake_reverse_all_ips_in_range(*, callback, **_kwargs) -> None:
+        events.append('reverse')
+        callback('ptr.example.com')
+
+    class FakeApiScanner:
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def do_search(self) -> None:
+            events.append('api-scan')
+
+        def get_found_endpoints(self):
+            return {'https://example.com/v1/status': SimpleNamespace(status_code=200)}
+
+        def get_interesting_endpoints(self):
+            return {}
+
+        def get_auth_required(self):
+            return {}
+
+        def get_api_versions(self):
+            return set()
+
+        def get_rate_limits(self):
+            return {}
+
+        def get_methods(self):
+            return {'GET'}
+
+        def get_status_codes(self):
+            return {200}
+
+    def capture_terminal(result) -> str:
+        events.append('terminal')
+        return output_module.format_run_terminal(result)
+
+    def capture_legacy_json(result, existing):
+        events.append('legacy-json')
+        return output_module.legacy_json_result(result, existing)
+
+    def capture_jsonl(result) -> str:
+        events.append('jsonl')
+        return output_module.run_result_jsonl(result)
+
+    monkeypatch.setattr(main_module, 'build_parser', lambda: FakeParser())
+    monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module.hostchecker, 'Checker', FakeHostChecker)
+    monkeypatch.setattr(main_module, 'AioDNSResolverVantage', FakeResolver)
+    monkeypatch.setattr(main_module.dnssearch, 'DnsForce', FakeDnsForce)
+    monkeypatch.setattr(main_module.dnssearch, 'serialize_ip_range', lambda **_kwargs: '192.0.2.0/24')
+    monkeypatch.setattr(main_module.dnssearch, 'reverse_all_ips_in_range', fake_reverse_all_ips_in_range)
+    monkeypatch.setattr(main_module.takeover, 'TakeOver', FakeTakeOver)
+    monkeypatch.setattr(main_module.api_endpoints, 'SearchApiEndpoints', FakeApiScanner)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore)
+    monkeypatch.setattr(run_module, 'SQLiteRunStore', FakeRunStore)
+    monkeypatch.setattr(main_module, 'format_run_terminal', capture_terminal)
+    monkeypatch.setattr(main_module, 'legacy_json_result', capture_legacy_json)
+    monkeypatch.setattr(main_module, 'run_result_jsonl', capture_jsonl)
+
+    with pytest.raises(SystemExit) as exit_info:
+        await main_module.start()
+
+    assert exit_info.value.code == 0
+    assert events == [
+        'collect',
+        'dns-brute',
+        'reverse',
+        'direct',
+        'api-scan',
+        'persist',
+        'terminal',
+        'legacy-json',
+        'jsonl',
+    ]
+    persisted = FakeRunStore.saved[0]
+    assert {entity.value for entity in persisted.entities} >= {
+        'late.example.com',
+        'ptr.example.com',
+    }
+    assert {(item.kind, item.value, item.detail) for item in persisted.selected_observations} == {
+        ('takeover', 'api.example.com', 'not vulnerable'),
+        ('api-endpoint', 'https://example.com/v1/status', '200'),
+    }
+    dns_execution = next(item for item in persisted.source_executions if item.source == 'action:dns-brute')
+    assert dns_execution.result_count == 2
+    assert dns_execution.observation_count == 1
+
+
+@pytest.mark.asyncio
+async def test_mixed_rest_sources_share_one_completed_persisted_run(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import theHarvester.__main__ as main_module
+
+    class FakeCrtshSearch:
+        def __init__(self, _target: str) -> None:
+            return None
+
+        async def process(self, _proxy: bool = False) -> None:
+            return None
+
+        async def get_hostnames(self) -> list[str]:
+            return ['red.example.com']
+
+    class FakeBaiduSearch:
+        def __init__(self, _target: str, _limit: int) -> None:
+            return None
+
+        async def process(self, _proxy: bool = False) -> None:
+            return None
+
+        async def get_hostnames(self) -> list[str]:
+            return ['blue.example.com']
+
+        async def get_emails(self) -> list[str]:
+            return ['blue-team@example.com']
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args) -> None:
+            return None
+
+    saved: list[RunResult] = []
+
+    class FakeRunStore:
+        async def save(self, result: RunResult) -> None:
+            saved.append(result)
+
+    monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
+    monkeypatch.setattr(main_module.baidusearch, 'SearchBaidu', FakeBaiduSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore)
+
+    response = await main_module.start(
+        SimpleNamespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=False,
+            screenshot='',
+            shodan=False,
+            source='baidu,crtsh',
+            start=0,
+            take_over=False,
+            wordlist='',
+        ),
+        return_evidence_run=True,
+    )
+
+    result = response[-1]
+    assert result is saved[0]
+    assert {entity.value for entity in result.entities} == {'blue.example.com', 'red.example.com'}
+    assert {execution.source.casefold() for execution in result.source_executions} == {'baidu', 'crtsh'}
+    assert {execution.source_family for execution in result.source_executions} == {
+        'web-search',
+        'certificate-transparency',
+    }
+    assert {(item.kind, item.value) for item in result.selected_observations} == {
+        (StageFindingKind.EMAIL, 'blue-team@example.com')
+    }
+    assert response[8] == ['blue.example.com', 'red.example.com']
+    records = [json.loads(line) for line in run_result_jsonl(result).splitlines()]
+    assert {record['data']['source'].casefold() for record in records if record['record_type'] == 'source_execution'} == {
+        'baidu',
+        'crtsh',
+    }
+    rest = legacy_json_result(result, {'hosts': response[8]})
+    assert rest['evidence_run']['run_id'] == result.run_id
+    terminal = capsys.readouterr().out
+    assert terminal.count('blue.example.com') == 1
+    assert terminal.count('red.example.com') == 1
+    assert terminal.count('blue-team@example.com') == 1
+
+
+@pytest.mark.asyncio
+async def test_rest_dns_brute_finishes_and_returns_the_same_persisted_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import theHarvester.__main__ as main_module
+
+    class FakeDnsForce:
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def run(self):
+            return ['late.example.com:192.0.2.11'], ['late.example.com'], ['192.0.2.11']
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, *_args) -> None:
+            return None
+
+    saved: list[RunResult] = []
+
+    class FakeRunStore:
+        async def save(self, result: RunResult) -> None:
+            saved.append(result)
+
+    monkeypatch.setattr(main_module.dnssearch, 'DnsForce', FakeDnsForce)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore)
+
+    response = await main_module.start(
+        SimpleNamespace(
+            api_scan=False,
+            dns_brute=True,
+            dns_lookup=False,
+            dns_resolve='',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=False,
+            screenshot='',
+            shodan=False,
+            source='',
+            start=0,
+            take_over=False,
+            wordlist='',
+        ),
+        return_evidence_run=True,
+    )
+
+    result = response[-1]
+    assert result is saved[0]
+    assert response[8] == ['late.example.com:192.0.2.11']
+    assert {entity.value for entity in result.entities} == {'late.example.com'}
+    execution = next(item for item in result.source_executions if item.source == 'action:dns-brute')
+    assert execution.status is SourceStatus.SUCCEEDED
+    assert legacy_json_result(result, {'hosts': response[8]})['evidence_run']['status'] == 'complete'

--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -52,6 +52,17 @@ class OneCandidateSource:
         return [SourceFinding(self.candidate)]
 
 
+class SourceWithFindings:
+    family = 'fixture-family'
+
+    def __init__(self, name: str, *values: str) -> None:
+        self.name = name
+        self.values = values
+
+    async def collect(self, _target: str) -> list[SourceFinding]:
+        return [SourceFinding(value) for value in self.values]
+
+
 class FakeResolverVantage:
     def __init__(self, name: str, candidate: str, response: DNSResponse) -> None:
         self.name = name
@@ -415,6 +426,28 @@ async def test_execute_run_records_scoped_normalized_evidence_end_to_end(tmp_pat
 
     assert await store.load(result.run_id) == result.to_dict()
     assert FakePassiveSource.raw_payload.encode() not in database.read_bytes()
+
+
+@pytest.mark.asyncio
+async def test_execute_run_reports_source_local_completeness_counts() -> None:
+    first = await execute_run(
+        'example.com',
+        SourceWithFindings('first', 'one.example.com', 'shared.example.com'),
+        persist=False,
+    )
+    result = await execute_run(
+        'example.com',
+        SourceWithFindings('second', 'shared.example.com', 'two.example.com', 'two.example.com'),
+        base_result=first,
+        persist=False,
+    )
+
+    assert [
+        (execution.source, execution.observation_count, execution.entity_count) for execution in result.source_executions
+    ] == [
+        ('first', 2, 2),
+        ('second', 3, 2),
+    ]
 
 
 class OutcomeSource:

--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -491,13 +491,21 @@ async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch
     evidence_store = SQLiteRunStore(tmp_path / 'evidence.sqlite')
     captured: list[run_module.RunResult] = []
 
-    async def execute_with_temporary_store(target, source):
-        result = await run_module.execute_run(target, source, store=evidence_store)
+    async def execute_with_temporary_store(target, source, *, persist: bool = True, base_result=None):
+        assert persist is False
+        result = await run_module.execute_run(
+            target,
+            source,
+            store=evidence_store,
+            persist=False,
+            base_result=base_result,
+        )
         captured.append(result)
         return result
 
     monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', lambda: evidence_store)
     monkeypatch.setattr(main_module, 'execute_run', execute_with_temporary_store, raising=True)
 
     await main_module.start(
@@ -524,7 +532,11 @@ async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch
     assert len(captured) == 1
     assert captured[0].source_executions[0].status is SourceStatus.SUCCEEDED
     assert legacy_hostnames(captured[0]) == ['www.example.com']
-    assert await evidence_store.load(captured[0].run_id) == captured[0].to_dict()
+    stored_result = await evidence_store.load(captured[0].run_id)
+    assert stored_result is not None
+    assert stored_result['run_id'] == captured[0].run_id
+    assert stored_result['status'] == 'complete'
+    assert stored_result['completed_at'] >= captured[0].completed_at.isoformat()
     assert stored == [('example.com', ('www.example.com',), 'host', 'CRTsh')]
 
 
@@ -599,8 +611,13 @@ async def test_crtsh_bridge_closes_constructed_vantages_after_partial_constructo
         async def close(self) -> None:
             closed.append(self.name)
 
+    class FakeRunStore:
+        async def save(self, _result) -> None:
+            return None
+
     monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
     monkeypatch.setattr(main_module, 'AioDNSResolverVantage', PartiallyFailingVantage, raising=True)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', FakeRunStore)
 
     await main_module.start(
         argparse.Namespace(
@@ -680,12 +697,17 @@ async def test_crtsh_bridge_uses_three_explicit_resolver_vantages(monkeypatch: p
         source: run_module.PassiveSource,
         *,
         resolver_vantages: tuple[run_module.ResolverVantage, ...] | None = None,
+        persist: bool = True,
+        base_result: run_module.RunResult | None = None,
     ) -> run_module.RunResult:
+        assert persist is False
+        assert resolver_vantages is None
         result = await run_module.execute_run(
             target,
             source,
-            resolver_vantages=resolver_vantages,
             store=evidence_store,
+            persist=False,
+            base_result=base_result,
         )
         captured.append(result)
         return result
@@ -694,6 +716,7 @@ async def test_crtsh_bridge_uses_three_explicit_resolver_vantages(monkeypatch: p
     monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
     monkeypatch.setattr(main_module.hostchecker, 'Checker', FakeHostChecker)
     monkeypatch.setattr(main_module, 'AioDNSResolverVantage', FakeProductionVantage, raising=True)
+    monkeypatch.setattr(main_module, 'SQLiteRunStore', lambda: evidence_store)
     monkeypatch.setattr(main_module, 'execute_run', execute_with_temporary_store, raising=True)
 
     await main_module.start(
@@ -718,4 +741,7 @@ async def test_crtsh_bridge_uses_three_explicit_resolver_vantages(monkeypatch: p
 
     assert set(created) == {'192.0.2.53', '192.0.2.54', '192.0.2.55'}
     assert set(closed) == set(created)
-    assert captured[0].entities[0].addressability is Addressability.CURRENT
+    assert captured[0].entities[0].addressability is Addressability.UNVERIFIED
+    stored_result = await evidence_store.load(captured[0].run_id)
+    assert stored_result is not None
+    assert stored_result['entities'][0]['addressability'] == 'currently-addressable'

--- a/tests/lib/test_source_catalog.py
+++ b/tests/lib/test_source_catalog.py
@@ -205,10 +205,11 @@ async def test_rest_query_canonicalizes_aliases_before_execution(monkeypatch: py
 
     captured_source = ''
 
-    async def fake_start(args):
+    async def fake_start(args, *, return_evidence_run: bool = False):
         nonlocal captured_source
+        assert return_evidence_run is True
         captured_source = args.source
-        return ([], [], [], [], [], [], [], [], [])
+        return ([], [], [], [], [], [], [], [], [], None)
 
     monkeypatch.setattr(api.__main__, 'start', fake_start)
 
@@ -225,10 +226,11 @@ async def test_rest_all_preserves_passive_selection_notice(monkeypatch: pytest.M
 
     captured_source = ''
 
-    async def fake_start(args):
+    async def fake_start(args, *, return_evidence_run: bool = False):
         nonlocal captured_source
+        assert return_evidence_run is True
         captured_source = args.source
-        return ([], [], [], [], [], [], [], [], [])
+        return ([], [], [], [], [], [], [], [], [], None)
 
     monkeypatch.setattr(api.__main__, 'start', fake_start)
 
@@ -245,10 +247,11 @@ async def test_cli_and_rest_resolve_equivalent_activity_options(monkeypatch: pyt
 
     captured_args = Namespace()
 
-    async def fake_start(args):
+    async def fake_start(args, *, return_evidence_run: bool = False):
         nonlocal captured_args
+        assert return_evidence_run is True
         captured_args = args
-        return ([], [], [], [], [], [], [], [], [])
+        return ([], [], [], [], [], [], [], [], [], None)
 
     monkeypatch.setattr(api.__main__, 'start', fake_start)
     await api.query.__wrapped__(

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -9,6 +9,7 @@ import time
 import traceback
 from collections.abc import Awaitable
 from contextlib import AsyncExitStack
+from dataclasses import replace
 from typing import Any
 
 import anyio
@@ -79,8 +80,32 @@ from theHarvester.discovery import (
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib import hostchecker, stash
 from theHarvester.lib.core import DATA_DIR, Core, show_default_error_message
-from theHarvester.lib.output import print_linkedin_sections, print_section, sorted_unique
-from theHarvester.lib.run import AioDNSResolverVantage, LegacyHostnameSource, execute_run, legacy_hostnames
+from theHarvester.lib.output import (
+    evidence_xml_fragment,
+    format_run_terminal,
+    legacy_json_result,
+    print_linkedin_sections,
+    print_section,
+    run_result_jsonl,
+    sorted_unique,
+)
+from theHarvester.lib.run import (
+    AioDNSResolverVantage,
+    LegacyHostnameSource,
+    SourceExecution,
+    SourceRateLimitedError,
+    SourceSkippedError,
+    SourceStatus,
+    SQLiteRunStore,
+    StageFinding,
+    StageFindingKind,
+    StageResult,
+    begin_run,
+    complete_run,
+    execute_run,
+    legacy_hostnames,
+    validate_unvalidated_entities,
+)
 from theHarvester.lib.source_catalog import SourceSchedule, canonical_source_names, describe_activity, resolve_sources
 from theHarvester.screenshot.screenshot import ScreenShotter
 
@@ -220,7 +245,7 @@ def selected_actions(args: argparse.Namespace) -> tuple[str, ...]:
     )
 
 
-async def start(rest_args: argparse.Namespace | None = None):
+async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_run: bool = False):
     """Main program function"""
     parser = build_parser()
 
@@ -233,11 +258,12 @@ async def start(rest_args: argparse.Namespace | None = None):
         elif rest_args.dns_brute:
             args = rest_args
             dnsbrute = (rest_args.dns_brute, True)
+            filename = args.filename
         else:
             args = rest_args
             dnsbrute = (args.dns_brute, False)
             # We need to make sure the filename is random as to not overwrite other files
-            filename: str = args.filename
+            filename = args.filename
             alphabet = string.ascii_letters + string.digits
             rest_filename += f'{"".join(secrets.choice(alphabet) for _ in range(32))}_{filename}' if len(filename) != 0 else ''
     else:
@@ -353,8 +379,40 @@ async def start(rest_args: argparse.Namespace | None = None):
 
     interesting_urls = []
     total_asns = []
+    completed_run_result = begin_run(word)
+    stage_results: list[StageResult] = []
+    dns_resolution_findings: list[StageFinding] = []
+    dns_resolution_errors: list[Exception] = []
+    dns_resolution_started = time.perf_counter()
+
+    def record_stage_result(
+        source: str,
+        started: float,
+        findings: list[StageFinding] | tuple[StageFinding, ...] = (),
+        error: Exception | None = None,
+    ) -> None:
+        unique_findings = tuple(dict.fromkeys(findings))
+        if isinstance(error, SourceRateLimitedError):
+            status = SourceStatus.RATE_LIMITED
+        elif isinstance(error, SourceSkippedError):
+            status = SourceStatus.SKIPPED
+        elif error is not None:
+            status = SourceStatus.FAILED
+        else:
+            status = SourceStatus.SUCCEEDED if unique_findings else SourceStatus.EMPTY
+        stage_results.append(
+            StageResult(
+                source=source,
+                status=status,
+                duration_ms=(time.perf_counter() - started) * 1000,
+                result_count=len(findings),
+                findings=unique_findings,
+                error_type=type(error).__name__ if error is not None else None,
+            )
+        )
 
     execution_schedule = SourceSchedule(source_plan)
+    source_families = {source.name: source.family for source in source_plan.sources}
 
     async def _store(
         search_engine: Any,
@@ -369,7 +427,8 @@ async def start(rest_args: argparse.Namespace | None = None):
         store_interestingurls: bool = False,
         store_asns: bool = False,
         evidence_source: LegacyHostnameSource | None = None,
-    ) -> None:
+        stage_findings: list[StageFinding] | None = None,
+    ) -> SourceExecution | None:
         """Persist details into the database.
         The details to be stored are controlled by the parameters passed to the method.
 
@@ -386,6 +445,7 @@ async def start(rest_args: argparse.Namespace | None = None):
         :param store_asns: whether to store asns
         :param evidence_source: optional adapter for a source migrated to the evidence-bearing run path
         """
+        nonlocal completed_run_result
         run_result = None
         if evidence_source is None:
             (
@@ -394,16 +454,13 @@ async def start(rest_args: argparse.Namespace | None = None):
                 else await search_engine.process(process_param, use_proxy)
             )
         else:
-            if len(final_dns_resolver_list) == 3:
-                resolver_vantages: list[AioDNSResolverVantage] = []
-                async with AsyncExitStack() as resolver_stack:
-                    for nameserver in final_dns_resolver_list:
-                        resolver = AioDNSResolverVantage(nameserver)
-                        resolver_vantages.append(resolver)
-                        resolver_stack.push_async_callback(resolver.close)
-                    run_result = await execute_run(word, evidence_source, resolver_vantages=resolver_vantages)
-            else:
-                run_result = await execute_run(word, evidence_source)
+            run_result = await execute_run(
+                word,
+                evidence_source,
+                persist=False,
+                base_result=completed_run_result,
+            )
+            completed_run_result = run_result
         db_stash = stash.StashManager()
 
         if source:
@@ -422,13 +479,18 @@ async def start(rest_args: argparse.Namespace | None = None):
                     # indicates that -r was passed in if dnsresolve is None
                     full_hosts_checker = hostchecker.Checker(host_names, final_dns_resolver_list)
                     # If full, this is only getting resolved hosts
-                    (
-                        resolved_pair,
-                        _temp_hosts,
-                        temp_ips,
-                    ) = await full_hosts_checker.check()
+                    try:
+                        (
+                            resolved_pair,
+                            _temp_hosts,
+                            temp_ips,
+                        ) = await full_hosts_checker.check()
+                    except Exception as error:
+                        dns_resolution_errors.append(error)
+                        raise
                     all_ip.extend(temp_ips)
                     full.extend(resolved_pair)
+                    dns_resolution_findings.extend(StageFinding(StageFindingKind.HOSTNAME, host) for host in resolved_pair)
                     # full.extend(temp_hosts)
                 else:
                     full.extend(host_names)
@@ -436,16 +498,22 @@ async def start(rest_args: argparse.Namespace | None = None):
                 full.extend(host_names)
             all_hosts.extend(host_names)
             await db_stash.store_all(word, all_hosts, 'host', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.HOSTNAME, host) for host in host_names)
 
         if store_emails:
             email_list = await search_engine.get_emails()
             all_emails.extend(email_list)
             await db_stash.store_all(word, email_list, 'email', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.EMAIL, email) for email in email_list)
 
         if store_ip:
             ips_list = await search_engine.get_ips()
             all_ip.extend(ips_list)
             await db_stash.store_all(word, all_ip, 'ip', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.IP_ADDRESS, str(ip)) for ip in ips_list)
 
         if store_results:
             email_list, host_names, urls = await search_engine.get_results()
@@ -455,29 +523,45 @@ async def start(rest_args: argparse.Namespace | None = None):
             all_hosts.extend(host_names)
             await db.store_all(word, all_hosts, 'host', source)
             await db.store_all(word, all_emails, 'email', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.EMAIL, email) for email in email_list)
+                stage_findings.extend(StageFinding(StageFindingKind.HOSTNAME, host) for host in host_names)
+                stage_findings.extend(StageFinding(StageFindingKind.URL, url) for url in urls)
 
         if store_people:
             people_list = await search_engine.get_people()
             all_people.extend(people_list)
             await db_stash.store_all(word, people_list, 'people', source)
+            if stage_findings is not None:
+                stage_findings.extend(
+                    StageFinding(StageFindingKind.PERSON, ujson.dumps(person, sort_keys=True)) for person in people_list
+                )
 
         if store_links:
             links = await search_engine.get_links()
             linkedin_links_tracker.extend(links)
             if len(links) > 0:
                 await db.store_all(word, links, 'linkedinlinks', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.URL, link) for link in links)
 
         if store_interestingurls:
             iurls = await search_engine.get_interestingurls()
             interesting_urls.extend(iurls)
             if len(iurls) > 0:
                 await db.store_all(word, iurls, 'interestingurls', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.INTERESTING_URL, url) for url in iurls)
 
         if store_asns:
             fasns = await search_engine.get_asns()
             total_asns.extend(fasns)
             if len(fasns) > 0:
                 await db.store_all(word, fasns, 'asns', source)
+            if stage_findings is not None:
+                stage_findings.extend(StageFinding(StageFindingKind.ASN, str(asn)) for asn in fasns)
+
+        return run_result.source_executions[-1] if run_result is not None else None
 
     def store(
         search_engine: Any,
@@ -487,7 +571,50 @@ async def start(rest_args: argparse.Namespace | None = None):
         **kwargs: Any,
     ) -> Awaitable[None]:
         execution_schedule.register(source, catalog_adapter if catalog_adapter is not None else search_engine)
-        return _store(search_engine, source, *args, **kwargs)
+
+        async def run_stage() -> None:
+            findings: list[StageFinding] = []
+            started = time.perf_counter()
+            execution = None
+            status = SourceStatus.FAILED
+            error_type = None
+            try:
+                kwargs['stage_findings'] = findings
+                execution = await _store(
+                    search_engine,
+                    source,
+                    *args,
+                    **kwargs,
+                )
+                status = (
+                    execution.status if execution is not None else (SourceStatus.SUCCEEDED if findings else SourceStatus.EMPTY)
+                )
+            except SourceRateLimitedError:
+                status = SourceStatus.RATE_LIMITED
+                raise
+            except (SourceSkippedError, MissingKey):
+                status = SourceStatus.SKIPPED
+                raise
+            except Exception as error:
+                error_type = type(error).__name__
+                raise
+            finally:
+                unique_findings = tuple(dict.fromkeys(findings))
+                stage_results.append(
+                    StageResult(
+                        source=source,
+                        source_family=(
+                            execution.source_family if execution is not None else source_families.get(source.casefold(), source)
+                        ),
+                        status=status,
+                        duration_ms=(time.perf_counter() - started) * 1000,
+                        result_count=execution.result_count if execution is not None else len(findings),
+                        findings=unique_findings,
+                        error_type=execution.error_type if execution is not None else error_type,
+                    )
+                )
+
+        return run_stage()
 
     stor_lst = []
     if args.source is not None:
@@ -1451,24 +1578,25 @@ async def start(rest_args: argparse.Namespace | None = None):
         await asyncio.gather(*tasks, return_exceptions=True)
 
     await handler(lst=stor_lst)
-    return_ips: list = []
-    if rest_args is not None and len(rest_filename) == 0 and rest_args.dns_brute is False:
-        # Indicates user is using REST api but not wanting output to be saved to a file
-        # cast to string so Rest API can understand the type
-        return_ips.extend([str(ip) for ip in sorted([netaddr.IPAddress(ip.strip()) for ip in set(all_ip)])])
-        # return list(set(all_emails)), return_ips, full, '', ''
-        all_hosts = [host.replace('www.', '') for host in all_hosts if host.replace('www.', '') in all_hosts]
-        all_hosts = list(sorted(set(all_hosts)))
-        return (
-            total_asns,
-            interesting_urls,
-            twitter_people_list_tracker,
-            linkedin_people_list_tracker,
-            linkedin_links_tracker,
-            all_urls,
-            all_ip,
-            all_emails,
-            all_hosts,
+    recorded_sources = {result.source.casefold() for result in stage_results}
+    for engine in engines:
+        if engine.casefold() not in recorded_sources:
+            stage_results.append(
+                StageResult(
+                    source=engine,
+                    source_family=source_families.get(engine, engine),
+                    status=SourceStatus.SKIPPED,
+                    duration_ms=0,
+                    result_count=0,
+                    error_type='SourceDidNotStart',
+                )
+            )
+    if 'dns-resolve' in selected_actions(args):
+        record_stage_result(
+            'action:dns-resolve',
+            dns_resolution_started,
+            dns_resolution_findings,
+            dns_resolution_errors[0] if dns_resolution_errors else None,
         )
     # Check to see if all_emails and all_hosts are defined.
     try:
@@ -1574,12 +1702,14 @@ async def start(rest_args: argparse.Namespace | None = None):
                     temp.add(host)
             full = list(sorted(temp))
             full.sort(key=lambda el: el.split(':')[0])
-            print('\n[*] Hosts found: ' + str(len(full)))
-            print('---------------------')
+            if completed_run_result is None:
+                print('\n[*] Hosts found: ' + str(len(full)))
+                print('---------------------')
             for host in full:
-                print(host)
+                if completed_run_result is None:
+                    print(host)
                 try:
-                    if ':' in host:
+                    if rest_args is None and ':' in host:
                         _, addr = host.split(':', 1)
                         await db.store(word, addr, 'ip', 'DNS-resolver')
                 except (OSError, RuntimeError, ValueError, TypeError) as e:
@@ -1588,19 +1718,25 @@ async def start(rest_args: argparse.Namespace | None = None):
         else:
             all_hosts = [host.replace('www.', '') for host in all_hosts if host.replace('www.', '') in all_hosts]
             all_hosts = list(sorted(set(all_hosts)))
-            print('\n[*] Hosts found: ' + str(len(all_hosts)))
-            print('---------------------')
-            for host in all_hosts:
-                print(host)
+            if completed_run_result is None:
+                print('\n[*] Hosts found: ' + str(len(all_hosts)))
+                print('---------------------')
+                for host in all_hosts:
+                    print(host)
 
     # DNS brute force
     if dnsbrute and dnsbrute[0] is True:
         print('\n[*] Starting DNS brute force.')
-        dns_force = dnssearch.DnsForce(word, final_dns_resolver_list, verbose=True)
-        resolved_pair, hosts, ips = await dns_force.run()
-        # Check if Rest API is being used if so return found hosts
-        if dnsbrute[1]:
-            return resolved_pair
+        stage_started = time.perf_counter()
+        try:
+            dns_force = dnssearch.DnsForce(word, final_dns_resolver_list, verbose=True)
+            resolved_pair, hosts, ips = await dns_force.run()
+            dns_brute_findings = [StageFinding(StageFindingKind.HOSTNAME, host) for host in resolved_pair]
+            record_stage_result('action:dns-brute', stage_started, dns_brute_findings)
+        except Exception as error:
+            resolved_pair, hosts, ips = [], [], []
+            record_stage_result('action:dns-brute', stage_started, error=error)
+            print(f'[!] DNS brute force failed: {error}')
         db = stash.StashManager()
         temp = set()
         for host in resolved_pair:
@@ -1629,20 +1765,12 @@ async def start(rest_args: argparse.Namespace | None = None):
             print(sub)
         await db.store_all(word, list(sorted(temp)), 'host', 'dns_bruteforce')
 
-    takeover_results = dict()
-    # TakeOver Checking
-    if takeover_status:
-        print('\n[*] Performing subdomain takeover check')
-        print('\n[*] Subdomain Takeover checking IS ACTIVE RECON')
-        search_take = takeover.TakeOver(all_hosts)
-        await search_take.populate_fingerprints()
-        await search_take.process(proxy=use_proxy)
-        takeover_results = await search_take.get_takeover_results()
     # DNS reverse lookup
     dnsrev: list = []
     # print(f'DNSlookup: {dnslookup}')
     if dnslookup is True:
         print('\n[*] Starting active queries for DNSLookup.')
+        stage_started = time.perf_counter()
 
         # reverse each iprange in a separate task
         __reverse_dns_tasks: dict = {}
@@ -1662,16 +1790,49 @@ async def start(rest_args: argparse.Namespace | None = None):
                 # nameservers=list(map(str, dnsserver.split(','))) if dnsserver else None))
 
         # run all the reversing tasks concurrently
-        await asyncio.gather(*__reverse_dns_tasks.values())
+        try:
+            await asyncio.gather(*__reverse_dns_tasks.values())
+            reverse_findings = [StageFinding(StageFindingKind.HOSTNAME, host) for host in dnsrev]
+            record_stage_result('action:dns-lookup', stage_started, reverse_findings)
+        except Exception as error:
+            record_stage_result('action:dns-lookup', stage_started, error=error)
+            print(f'[!] Reverse DNS lookup failed: {error}')
         print('\n[*] Hosts found after reverse lookup (in target domain):')
         print('--------------------------------------------------------')
         for xh in dnsrev:
             print(xh)
 
+    takeover_results = dict()
+    # TakeOver Checking
+    if takeover_status:
+        print('\n[*] Performing subdomain takeover check')
+        print('\n[*] Subdomain Takeover checking IS ACTIVE RECON')
+        stage_started = time.perf_counter()
+        try:
+            search_take = takeover.TakeOver(all_hosts)
+            await search_take.populate_fingerprints()
+            await search_take.process(proxy=use_proxy)
+            takeover_results = await search_take.get_takeover_results()
+            takeover_findings = [
+                StageFinding(
+                    StageFindingKind.TAKEOVER,
+                    str(host),
+                    result if isinstance(result, str) else ujson.dumps(result, sort_keys=True),
+                )
+                for host, result in takeover_results.items()
+            ]
+            record_stage_result('action:take-over', stage_started, takeover_findings)
+        except Exception as error:
+            record_stage_result('action:take-over', stage_started, error=error)
+            print(f'[!] Takeover check failed: {error}')
+
     # Screenshots
     screenshot_tups = []
-    if len(args.screenshot) > 0:
-        screen_shotter = ScreenShotter(args.screenshot)
+    screenshot_hosts: list[str] = []
+    screenshot_path = getattr(args, 'screenshot', '')
+    if len(screenshot_path) > 0:
+        stage_started = time.perf_counter()
+        screen_shotter = ScreenShotter(screenshot_path)
         path_exists = screen_shotter.verify_path()
         # Verify the path exists, if not create it or if user does not create it skips screenshot
         if path_exists:
@@ -1693,6 +1854,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                     results = await pool.map(screen_shotter.visit, list(unique_resolved_domains))
                     # Filter out domains that we couldn't connect to
                     unique_resolved_domains_list = list(sorted({tup[0] for tup in results if len(tup[1]) > 0}))
+                    screenshot_hosts.extend(unique_resolved_domains_list)
                 async with Pool(3) as pool:
                     print(f'Length of unique resolved domains: {len(unique_resolved_domains_list)} chunking now!\n')
                     # If you have the resources, you could make the function faster by increasing the chunk number
@@ -1710,10 +1872,18 @@ async def start(rest_args: argparse.Namespace | None = None):
             total_time = f'{mon:02d}:{sec:02d}'
             print(f'Finished taking screenshots in {total_time} seconds')
             print('[+] Note there may be leftover chrome processes you may have to kill manually\n')
+        record_stage_result(
+            'action:screenshot',
+            stage_started,
+            [StageFinding(StageFindingKind.SCREENSHOT, host) for host in screenshot_hosts],
+        )
 
     # Shodan
     shodanres = []
+    shodan_findings: list[StageFinding] = []
+    shodan_errors: list[Exception] = []
     if shodan is True:
+        stage_started = time.perf_counter()
         print('[*] Searching Shodan. ')
         try:
             for ip in host_ip:
@@ -1738,15 +1908,170 @@ async def start(rest_args: argparse.Namespace | None = None):
                                 value = ', '.join(map(str, value))
                             rowdata.append(value)
                         shodanres.append(rowdata)
+                        shodan_findings.append(
+                            StageFinding(
+                                StageFindingKind.SHODAN_RESULT,
+                                ip,
+                                ujson.dumps(shodandict[ip], sort_keys=True),
+                            )
+                        )
                         print(ujson.dumps(shodandict[ip], indent=4, sort_keys=True))
                         print('\n')
                 except Exception as ip_error:
+                    shodan_errors.append(ip_error)
                     print(f'[SHODAN-error] Error searching {ip}: {ip_error}')
                     continue
         except Exception as e:
+            shodan_errors.append(e)
             print(f'[!] An error occurred with Shodan: {e} ')
+        record_stage_result(
+            'action:shodan',
+            stage_started,
+            shodan_findings,
+            shodan_errors[0] if shodan_errors else None,
+        )
     else:
         pass
+
+    # Explicit API work must finish before the evidence run is completed or reported.
+    if args.api_scan or 'api_endpoints' in engines:
+        stage_started = time.perf_counter()
+        try:
+            wordlist = args.wordlist or str(DATA_DIR / 'wordlists' / 'api_endpoints.txt')
+
+            if not await anyio.Path(wordlist).exists():
+                print(f'\n[!] Wordlist not found: {wordlist}')
+                print('Creating a basic API wordlist for scanning...')
+                basic_endpoints = [
+                    '/api',
+                    '/api/v1',
+                    '/api/v2',
+                    '/api/v3',
+                    '/graphql',
+                    '/swagger',
+                    '/docs',
+                    '/redoc',
+                    '/swagger-ui',
+                    '/openapi.json',
+                    '/api-docs',
+                    '/rest',
+                    '/ws',
+                    '/swagger-ui.html',
+                    '/health',
+                    '/status',
+                    '/metrics',
+                    '/actuator',
+                    '/debug',
+                ]
+                temp_wordlist = str(DATA_DIR / 'wordlists' / 'temp_api_endpoints.txt')
+                async with await anyio.open_file(temp_wordlist, 'w') as f:
+                    await f.write('\n'.join(basic_endpoints))
+                wordlist = temp_wordlist
+                print(f'Basic API wordlist created with {len(basic_endpoints)} endpoints.')
+
+            print(f'\n[*] Starting API endpoint scanning with wordlist: {wordlist}')
+            api_scanner = api_endpoints.SearchApiEndpoints(word=args.domain, wordlist=wordlist)
+            await api_scanner.do_search()
+
+            endpoints_found = api_scanner.get_found_endpoints()
+            print(f'\n[*] API Endpoints found: {len(endpoints_found)}')
+            for endpoint in endpoints_found:
+                print(f'    - {endpoint}')
+            api_findings = [
+                StageFinding(StageFindingKind.API_ENDPOINT, endpoint, str(result.status_code))
+                for endpoint, result in endpoints_found.items()
+            ]
+
+            interesting_endpoints = api_scanner.get_interesting_endpoints()
+            print(f'\n[*] Interesting endpoints (200, 201, 202): {len(interesting_endpoints)}')
+            for endpoint in interesting_endpoints:
+                print(f'    - {endpoint}')
+
+            auth_required = api_scanner.get_auth_required()
+            print(f'\n[*] Endpoints requiring authentication: {len(auth_required)}')
+            for endpoint in auth_required:
+                print(f'    - {endpoint}')
+
+            api_versions = api_scanner.get_api_versions()
+            print(f'\n[*] Detected API versions: {len(api_versions)}')
+            for version in api_versions:
+                print(f'    - {version}')
+
+            rate_limits = api_scanner.get_rate_limits()
+            print(f'\n[*] Rate limited endpoints: {len(rate_limits)}')
+            for endpoint, info in rate_limits.items():
+                print(f'    - {endpoint} ({info.method})')
+
+            methods = api_scanner.get_methods()
+            print(f'\n[*] HTTP methods used: {", ".join(methods)}')
+
+            status_codes = api_scanner.get_status_codes()
+            print(f'\n[*] HTTP status codes encountered: {", ".join(map(str, status_codes))}')
+
+            db = stash.StashManager()
+            await db.store_all(word, endpoints_found, 'api_endpoint', 'api_scan')
+
+            if interesting_endpoints:
+                new_urls = [f'https://{args.domain}{endpoint}' for endpoint in interesting_endpoints]
+                interesting_urls.extend(new_urls)
+                all_urls.extend(new_urls)
+
+            record_stage_result('action:api-scan', stage_started, api_findings)
+            print('\n[+] API scanning completed successfully.')
+        except MissingKey as error:
+            record_stage_result('action:api-scan', stage_started, error=SourceSkippedError(str(error)))
+            print('\n[!] API endpoint scanning requires a wordlist. Use -w to specify a wordlist file.')
+            print('    Creating a basic wordlist and trying again...')
+        except Exception as e:
+            record_stage_result('action:api-scan', stage_started, error=e)
+            print(f'\n[!] An exception has occurred in API Endpoints scanning: {e}')
+            print('    Continuing with the rest of the scan...')
+            traceback.print_exc()
+
+    recorded_stages = {result.source.casefold() for result in stage_results}
+    for action in selected_actions(args):
+        stage_source = f'action:{action}'
+        if stage_source.casefold() not in recorded_stages:
+            stage_results.append(
+                StageResult(
+                    source=stage_source,
+                    status=SourceStatus.SKIPPED,
+                    duration_ms=0,
+                    result_count=0,
+                    error_type='StageDidNotStart',
+                )
+            )
+
+    completed_run_result = complete_run(completed_run_result, stage_results)
+    if len(final_dns_resolver_list) == 3:
+        try:
+            resolver_vantages: list[AioDNSResolverVantage] = []
+            async with AsyncExitStack() as resolver_stack:
+                for nameserver in final_dns_resolver_list:
+                    resolver = AioDNSResolverVantage(nameserver)
+                    resolver_vantages.append(resolver)
+                    resolver_stack.push_async_callback(resolver.close)
+                completed_run_result = await validate_unvalidated_entities(
+                    completed_run_result,
+                    resolver_vantages,
+                )
+        except Exception as error:
+            completed_run_result = replace(
+                completed_run_result,
+                source_executions=tuple(
+                    replace(
+                        execution,
+                        status=SourceStatus.FAILED,
+                        error_type=type(error).__name__,
+                    )
+                    if execution.source == 'action:dns-resolve'
+                    else execution
+                    for execution in completed_run_result.source_executions
+                ),
+            )
+            print(f'[!] DNS validation failed: {error}')
+    await SQLiteRunStore().save(completed_run_result)
+    print(format_run_terminal(completed_run_result))
 
     if filename != '':
         print('\n[*] Reporting started.')
@@ -1778,6 +2103,8 @@ async def start(rest_args: argparse.Namespace | None = None):
                         )
                     else:
                         await file.write(f'<vhost>{sanitize_for_xml(host)}</vhost>')
+                if completed_run_result is not None:
+                    await file.write(evidence_xml_fragment(completed_run_result))
                 # TODO add Shodan output into XML report
                 await file.write('</theHarvester>')
                 print('[*] XML File saved.')
@@ -1835,121 +2162,24 @@ async def start(rest_args: argparse.Namespace | None = None):
                 json_dict['takeover_results'] = takeover_results
 
             json_dict['shodan'] = shodanres
+            if completed_run_result is not None:
+                json_dict = legacy_json_result(completed_run_result, json_dict)
             async with await anyio.open_file(filename, 'w+') as fp:
                 dumped_json = ujson.dumps(json_dict, sort_keys=True)
                 await fp.write(dumped_json)
             print('[*] JSON File saved.')
+            if completed_run_result is not None:
+                jsonl_filename = filename.rsplit('.', 1)[0] + '.jsonl'
+                async with await anyio.open_file(jsonl_filename, 'w+') as fp:
+                    await fp.write(run_result_jsonl(completed_run_result) + '\n')
+                print('[*] JSONL File saved.')
         except (OSError, ValueError, TypeError, UnicodeEncodeError) as er:
             print(f'[!] An error occurred while saving the JSON file: {er} ')
         print('\n\n')
 
-    # Enhanced code block for API Endpoint scanning feature
-    if args.api_scan or 'api_endpoints' in engines:
-        try:
-            # Define a default wordlist if none is specified
-            wordlist = args.wordlist or str(DATA_DIR / 'wordlists' / 'api_endpoints.txt')
-
-            if not await anyio.Path(wordlist).exists():
-                print(f'\n[!] Wordlist not found: {wordlist}')
-                print('Creating a basic API wordlist for scanning...')
-                # Create a default simple API endpoint list
-                basic_endpoints = [
-                    '/api',
-                    '/api/v1',
-                    '/api/v2',
-                    '/api/v3',
-                    '/graphql',
-                    '/swagger',
-                    '/docs',
-                    '/redoc',
-                    '/swagger-ui',
-                    '/openapi.json',
-                    '/api-docs',
-                    '/rest',
-                    '/ws',
-                    '/swagger-ui.html',
-                    '/health',
-                    '/status',
-                    '/metrics',
-                    '/actuator',
-                    '/debug',
-                ]
-                temp_wordlist = str(DATA_DIR / 'wordlists' / 'temp_api_endpoints.txt')
-                async with await anyio.open_file(temp_wordlist, 'w') as f:
-                    await f.write('\n'.join(basic_endpoints))
-                wordlist = temp_wordlist
-                print(f'Basic API wordlist created with {len(basic_endpoints)} endpoints.')
-
-            print(f'\n[*] Starting API endpoint scanning with wordlist: {wordlist}')
-            api_scanner = api_endpoints.SearchApiEndpoints(word=args.domain, wordlist=wordlist)
-            await api_scanner.do_search()
-
-            # Print results
-            endpoints_found = api_scanner.get_found_endpoints()
-            print(f'\n[*] API Endpoints found: {len(endpoints_found)}')
-            for endpoint in endpoints_found:
-                print(f'    - {endpoint}')
-
-            interesting_endpoints = api_scanner.get_interesting_endpoints()
-            print(f'\n[*] Interesting endpoints (200, 201, 202): {len(interesting_endpoints)}')
-            for endpoint in interesting_endpoints:
-                print(f'    - {endpoint}')
-
-            auth_required = api_scanner.get_auth_required()
-            print(f'\n[*] Endpoints requiring authentication: {len(auth_required)}')
-            for endpoint in auth_required:
-                print(f'    - {endpoint}')
-
-            api_versions = api_scanner.get_api_versions()
-            print(f'\n[*] Detected API versions: {len(api_versions)}')
-            for version in api_versions:
-                print(f'    - {version}')
-
-            rate_limits = api_scanner.get_rate_limits()
-            print(f'\n[*] Rate limited endpoints: {len(rate_limits)}')
-            for endpoint, info in rate_limits.items():
-                print(f'    - {endpoint} ({info.method})')
-
-            methods = api_scanner.get_methods()
-            print(f'\n[*] HTTP methods used: {", ".join(methods)}')
-
-            status_codes = api_scanner.get_status_codes()
-            print(f'\n[*] HTTP status codes encountered: {", ".join(map(str, status_codes))}')
-
-            # Add results to storage
-            db = stash.StashManager()
-            await db.store_all(word, endpoints_found, 'api_endpoint', 'api_scan')
-
-            # Use custom database function if available
-            try:
-                # Try to use the storage module if available
-                db_storage = stash.StashManager()
-                await db_storage.store_all(word, endpoints_found, 'api_endpoint', 'api_scan')
-            except AttributeError:
-                print('\n[*] No custom database functions found')
-
-            # Add to interesting URLs if any endpoints were found
-            if interesting_endpoints:
-                new_urls = [f'https://{args.domain}{endpoint}' for endpoint in interesting_endpoints]
-                interesting_urls.extend(new_urls)
-
-                # Also add complete domain paths to the interesting_urls list
-                all_urls.extend(new_urls)
-
-            print('\n[+] API scanning completed successfully.')
-
-        except MissingKey:
-            print('\n[!] API endpoint scanning requires a wordlist. Use -w to specify a wordlist file.')
-            print('    Creating a basic wordlist and trying again...')
-            # The wordlist creation code above could be used here
-        except Exception as e:
-            print(f'\n[!] An exception has occurred in API Endpoints scanning: {e}')
-            print('    Continuing with the rest of the scan...')
-            traceback.print_exc()  # More detailed error information for developers
-
     if rest_args is not None:
         all_hosts = sorted({host.replace('www.', '') for host in all_hosts})
-        return (
+        response = (
             total_asns,
             interesting_urls,
             twitter_people_list_tracker,
@@ -1960,6 +2190,7 @@ async def start(rest_args: argparse.Namespace | None = None):
             all_emails,
             all_hosts,
         )
+        return (*response, completed_run_result) if return_evidence_run else response
     sys.exit(0)
 
 

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -207,7 +207,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         '-f',
         '--filename',
-        help='Save the results to an XML and JSON file.',
+        help='Save XML, legacy JSON, and normalized JSONL reports.',
         default='',
         type=str,
     )

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -104,6 +104,7 @@ from theHarvester.lib.run import (
     complete_run,
     execute_run,
     legacy_hostnames,
+    person_stage_finding,
     validate_unvalidated_entities,
 )
 from theHarvester.lib.source_catalog import SourceSchedule, canonical_source_names, describe_activity, resolve_sources
@@ -533,9 +534,9 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
             all_people.extend(people_list)
             await db_stash.store_all(word, people_list, 'people', source)
             if stage_findings is not None:
-                stage_findings.extend(
-                    StageFinding(StageFindingKind.PERSON, ujson.dumps(person, sort_keys=True)) for person in people_list
-                )
+                for person in people_list:
+                    if finding := person_stage_finding(person):
+                        stage_findings.append(finding)
 
         if store_links:
             links = await search_engine.get_links()
@@ -1912,7 +1913,7 @@ async def start(rest_args: argparse.Namespace | None = None, *, return_evidence_
                             StageFinding(
                                 StageFindingKind.SHODAN_RESULT,
                                 ip,
-                                ujson.dumps(shodandict[ip], sort_keys=True),
+                                attributes=dict(shodandict[ip]),
                             )
                         )
                         print(ujson.dumps(shodandict[ip], indent=4, sort_keys=True))

--- a/theHarvester/lib/api/api.py
+++ b/theHarvester/lib/api/api.py
@@ -17,6 +17,7 @@ from starlette.staticfiles import StaticFiles
 
 from theHarvester import __main__
 from theHarvester.lib.api.additional_endpoints import router as additional_router
+from theHarvester.lib.output import legacy_json_result
 from theHarvester.lib.source_catalog import resolve_sources
 
 API_RATE_LIMIT = os.getenv('API_RATE_LIMIT', '5/minute')
@@ -236,7 +237,7 @@ async def dnsbrute(
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Domain must be at least 3 characters long')
 
         # Call the main function with the provided parameters
-        dns_bruteforce = await __main__.start(
+        *_, dns_bruteforce = await __main__.start(
             argparse.Namespace(
                 dns_brute=True,
                 dns_lookup=False,
@@ -254,6 +255,8 @@ async def dnsbrute(
                 wordlist='',
                 api_scan=False,
                 dns_resolve=dns_resolve,
+                quiet=False,
+                screenshot='',
             )
         )
 
@@ -342,6 +345,7 @@ async def query(
             aips,
             aemails,
             ahosts,
+            evidence_run,
         ) = await __main__.start(
             argparse.Namespace(
                 dns_brute=dns_brute,
@@ -360,23 +364,23 @@ async def query(
                 dns_resolve=dns_resolve,
                 quiet=False,
                 screenshot='',
-            )
+            ),
+            return_evidence_run=True,
         )
 
         # Return the results using the Pydantic model
-        return JSONResponse(
-            {
-                'asns': asns,
-                'interesting_urls': iurls,
-                'twitter_people': twitter_people_list,
-                'linkedin_people': linkedin_people_list,
-                'linkedin_links': linkedin_links,
-                'trello_urls': aurls,
-                'ips': aips,
-                'emails': aemails,
-                'hosts': ahosts,
-            }
-        )
+        response_data = {
+            'asns': asns,
+            'interesting_urls': iurls,
+            'twitter_people': twitter_people_list,
+            'linkedin_people': linkedin_people_list,
+            'linkedin_links': linkedin_links,
+            'trello_urls': aurls,
+            'ips': aips,
+            'emails': aemails,
+            'hosts': ahosts,
+        }
+        return JSONResponse(legacy_json_result(evidence_run, response_data) if evidence_run is not None else response_data)
     except HTTPException as e:
         # Re-raise HTTP exceptions
         raise e

--- a/theHarvester/lib/output.py
+++ b/theHarvester/lib/output.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Hashable, Iterable, Sequence
-from typing import TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
+from xml.etree.ElementTree import Element, SubElement, tostring
+
+from theHarvester.lib.run import Addressability, ScopeClass, legacy_hostnames
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from theHarvester.lib.run import MergedEntity, RunResult, SelectedObservation
 
 T = TypeVar('T', bound=Hashable)
 
@@ -35,3 +44,145 @@ def print_linkedin_sections(
         print(separator)
         for link in sorted_unique(links):
             print(link)
+
+
+def _entity_line(entity: MergedEntity, selected: Sequence[SelectedObservation] = ()) -> str:
+    sources = ','.join(sorted({observation.source for observation in entity.observations}))
+    selected_status = ''.join(f'; {observation.kind}={observation.detail or "observed"}' for observation in selected)
+    return f'{entity.value} [status={entity.addressability}; sources={sources}{selected_status}]'
+
+
+def format_run_terminal(result: RunResult) -> str:
+    """Render one concise terminal report from a completed evidence run."""
+    primary = [
+        entity
+        for entity in result.entities
+        if ScopeClass.IN_SCOPE in entity.scope_classes and entity.addressability is Addressability.CURRENT
+    ]
+    primary_values = {entity.value for entity in primary}
+    secondary = [
+        entity
+        for entity in result.entities
+        if entity.value not in primary_values
+        and (
+            ScopeClass.EXTERNAL_RELATIONSHIP in entity.scope_classes
+            or (ScopeClass.IN_SCOPE in entity.scope_classes and entity.addressability is not Addressability.CURRENT)
+        )
+    ]
+    reported_values = primary_values | {entity.value for entity in secondary}
+    scope_extensions = [
+        entity
+        for entity in result.entities
+        if entity.value not in reported_values and ScopeClass.SCOPE_EXTENSION in entity.scope_classes
+    ]
+    entity_values = {entity.value for entity in result.entities}
+    terminal_selected = tuple(
+        observation for observation in result.selected_observations if observation.source.startswith('action:')
+    )
+    selected_by_entity = {
+        value: tuple(observation for observation in terminal_selected if observation.value == value) for value in entity_values
+    }
+    standalone_selected = [observation for observation in terminal_selected if observation.value not in entity_values]
+    sections = [
+        f'[*] Run status: {result.status}',
+        f'[*] Currently addressable subdomains ({len(primary)})',
+        *(_entity_line(entity, selected_by_entity[entity.value]) for entity in primary),
+        f'[*] Secondary evidence / needs review ({len(secondary)})',
+        *(_entity_line(entity, selected_by_entity[entity.value]) for entity in secondary),
+        f'[*] Scope-extension candidates ({len(scope_extensions)})',
+        *(_entity_line(entity, selected_by_entity[entity.value]) for entity in scope_extensions),
+        f'[*] Selected stage observations ({len(standalone_selected)})',
+        *(
+            f'{observation.value} [{observation.kind}={observation.detail or "observed"}; source={observation.source}]'
+            for observation in standalone_selected
+        ),
+        '[*] Source executions',
+        *(
+            f'{execution.source} [status={execution.status}; results={execution.result_count}; '
+            f'observations={execution.observation_count}]'
+            for execution in result.source_executions
+        ),
+    ]
+    return '\n'.join(sections)
+
+
+def run_result_jsonl(result: RunResult) -> str:
+    """Serialize a completed run as versioned, normalized evidence records."""
+    records: list[tuple[str, dict[str, Any]]] = [
+        (
+            'run',
+            _run_record(result),
+        ),
+        *(('source_execution', execution.to_dict()) for execution in result.source_executions),
+        *(('discovery_observation', observation.to_dict()) for observation in result.observations),
+        *(('dns_validation_observation', _jsonl_validation(observation.to_dict())) for observation in result.dns_validations),
+        *(('merged_result', _jsonl_entity(entity)) for entity in result.entities),
+        *(('selected_observation', observation.to_dict()) for observation in result.selected_observations),
+    ]
+    return '\n'.join(
+        json.dumps({'schema_version': 'theharvester-evidence-v1', 'record_type': record_type, 'data': data})
+        for record_type, data in records
+    )
+
+
+def _jsonl_validation(data: dict[str, object]) -> dict[str, object]:
+    data['validated_at'] = data.pop('queried_at')
+    return data
+
+
+def _jsonl_entity(entity: MergedEntity) -> dict[str, object]:
+    return {
+        'value': entity.value,
+        'addressability': entity.addressability,
+        'scope_classes': list(entity.scope_classes),
+        'independent_corroboration_count': entity.independent_corroboration_count,
+        'provenance': [observation.to_dict() for observation in entity.observations],
+    }
+
+
+def _evidence_summary(result: RunResult) -> dict[str, object]:
+    return {
+        **_run_record(result),
+        'source_executions': [execution.to_dict() for execution in result.source_executions],
+        'selected_observations': [observation.to_dict() for observation in result.selected_observations],
+    }
+
+
+def _run_record(result: RunResult) -> dict[str, object]:
+    return {
+        'run_id': result.run_id,
+        'target': result.target,
+        'status': result.status,
+        'started_at': result.started_at.isoformat(),
+        'completed_at': result.completed_at.isoformat(),
+    }
+
+
+def legacy_json_result(result: RunResult, existing: Mapping[str, object] | None = None) -> dict[str, object]:
+    adapted = dict(existing or {})
+    existing_hosts = adapted.get('hosts', [])
+    hosts = list(existing_hosts) if isinstance(existing_hosts, list) else []
+    adapted['hosts'] = list(dict.fromkeys([*hosts, *legacy_hostnames(result)]))
+    adapted['evidence_run'] = _evidence_summary(result)
+    return adapted
+
+
+def evidence_xml_fragment(result: RunResult) -> str:
+    return tostring(_evidence_xml_element(result), encoding='unicode')
+
+
+def _evidence_xml_element(result: RunResult) -> Element:
+    evidence_run = Element('evidence_run', run_id=result.run_id, status=result.status)
+    for execution in result.source_executions:
+        SubElement(evidence_run, 'source', name=execution.source, status=execution.status)
+    for observation in result.selected_observations:
+        attributes = {
+            'source': observation.source,
+            'kind': observation.kind,
+            'value': observation.value,
+            'collected_at': observation.collected_at.isoformat(),
+        }
+        if observation.detail is not None:
+            attributes['detail'] = observation.detail
+        SubElement(evidence_run, 'selected_observation', attributes)
+    return evidence_run

--- a/theHarvester/lib/output.py
+++ b/theHarvester/lib/output.py
@@ -120,7 +120,15 @@ def run_result_jsonl(result: RunResult) -> str:
         *(('selected_observation', observation.to_dict()) for observation in result.selected_observations),
     ]
     return '\n'.join(
-        json.dumps({'schema_version': 'theharvester-evidence-v1', 'record_type': record_type, 'data': data})
+        json.dumps(
+            {
+                'schema_version': 'theharvester-evidence-v1',
+                'run_id': result.run_id,
+                'target': result.target,
+                'record_type': record_type,
+                'data': data,
+            }
+        )
         for record_type, data in records
     )
 
@@ -155,6 +163,13 @@ def _run_record(result: RunResult) -> dict[str, object]:
         'status': result.status,
         'started_at': result.started_at.isoformat(),
         'completed_at': result.completed_at.isoformat(),
+        'record_counts': {
+            'source_executions': len(result.source_executions),
+            'discovery_observations': len(result.observations),
+            'dns_validation_observations': len(result.dns_validations),
+            'merged_results': len(result.entities),
+            'selected_observations': len(result.selected_observations),
+        },
     }
 
 

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -46,6 +46,12 @@ class SourceStatus(StrEnum):
     SKIPPED = 'skipped'
 
 
+class RunStatus(StrEnum):
+    COMPLETE = 'complete'
+    PARTIAL = 'partial'
+    FAILED = 'failed'
+
+
 class SourceRateLimitedError(Exception):
     pass
 
@@ -58,6 +64,62 @@ class SourceSkippedError(Exception):
 class SourceFinding:
     value: str
     derivation: Derivation = Derivation.PROVIDER
+    observed_at: datetime | None = None
+
+
+class StageFindingKind(StrEnum):
+    HOSTNAME = 'hostname'
+    EMAIL = 'email'
+    IP_ADDRESS = 'ip-address'
+    PERSON = 'person'
+    URL = 'url'
+    INTERESTING_URL = 'interesting-url'
+    ASN = 'asn'
+    TAKEOVER = 'takeover'
+    API_ENDPOINT = 'api-endpoint'
+    SCREENSHOT = 'screenshot'
+    SHODAN_RESULT = 'shodan-result'
+
+
+@dataclass(frozen=True)
+class StageFinding:
+    kind: StageFindingKind
+    value: str
+    detail: str | None = None
+    derivation: Derivation = Derivation.PROVIDER
+
+
+@dataclass(frozen=True)
+class StageResult:
+    source: str
+    status: SourceStatus
+    duration_ms: float
+    result_count: int
+    findings: tuple[StageFinding, ...] = ()
+    source_family: str | None = None
+    error_type: str | None = None
+
+
+@dataclass(frozen=True)
+class SelectedObservation:
+    run_id: str
+    source: str
+    kind: str
+    value: str
+    detail: str | None
+    derivation: Derivation
+    collected_at: datetime
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            'run_id': self.run_id,
+            'source': self.source,
+            'kind': self.kind,
+            'value': self.value,
+            'detail': self.detail,
+            'derivation': self.derivation,
+            'collected_at': self.collected_at.isoformat(),
+        }
 
 
 class PassiveSource(Protocol):
@@ -201,9 +263,10 @@ class DiscoveryObservation:
     derivation: Derivation
     collected_at: datetime
     scope_class: ScopeClass
+    provider_observed_at: datetime | None = None
 
     def to_dict(self) -> dict[str, str]:
-        return {
+        result = {
             'run_id': self.run_id,
             'target': self.target,
             'value': self.value,
@@ -213,6 +276,9 @@ class DiscoveryObservation:
             'collected_at': self.collected_at.isoformat(),
             'scope_class': self.scope_class,
         }
+        if self.provider_observed_at is not None:
+            result['provider_observed_at'] = self.provider_observed_at.isoformat()
+        return result
 
 
 @dataclass(frozen=True)
@@ -315,6 +381,20 @@ class RunResult:
     observations: tuple[DiscoveryObservation, ...]
     dns_validations: tuple[DNSValidationObservation, ...]
     entities: tuple[MergedEntity, ...]
+    selected_observations: tuple[SelectedObservation, ...] = ()
+
+    @property
+    def status(self) -> RunStatus:
+        incomplete = {
+            SourceStatus.FAILED,
+            SourceStatus.RATE_LIMITED,
+            SourceStatus.SKIPPED,
+        }
+        if self.source_executions and all(execution.status is SourceStatus.FAILED for execution in self.source_executions):
+            return RunStatus.FAILED
+        if any(execution.status in incomplete for execution in self.source_executions):
+            return RunStatus.PARTIAL
+        return RunStatus.COMPLETE
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -322,10 +402,12 @@ class RunResult:
             'target': self.target,
             'started_at': self.started_at.isoformat(),
             'completed_at': self.completed_at.isoformat(),
+            'status': self.status,
             'source_executions': [execution.to_dict() for execution in self.source_executions],
             'observations': [observation.to_dict() for observation in self.observations],
             'dns_validations': [observation.to_dict() for observation in self.dns_validations],
             'entities': [entity.to_dict() for entity in self.entities],
+            'selected_observations': [observation.to_dict() for observation in self.selected_observations],
         }
 
 
@@ -357,6 +439,21 @@ class SQLiteRunStore:
             cursor = await database.execute('SELECT evidence_json FROM evidence_runs WHERE run_id = ?', (run_id,))
             row = await cursor.fetchone()
         return json.loads(row[0]) if row is not None else None
+
+
+def begin_run(target: str) -> RunResult:
+    """Create an empty evidence run for one finite invocation."""
+    started_at = datetime.now(UTC)
+    return RunResult(
+        run_id=str(uuid4()),
+        target=_normalize_hostname(target),
+        started_at=started_at,
+        completed_at=started_at,
+        source_executions=(),
+        observations=(),
+        dns_validations=(),
+        entities=(),
+    )
 
 
 def _normalize_hostname(value: str) -> str:
@@ -527,15 +624,20 @@ async def execute_run(
     *,
     resolver_vantages: Sequence[ResolverVantage] | None = None,
     store: SQLiteRunStore | None = None,
+    persist: bool = True,
+    base_result: RunResult | None = None,
 ) -> RunResult:
     if resolver_vantages is not None and (
         len(resolver_vantages) != _RESOLVER_VANTAGE_COUNT
         or len({resolver.name for resolver in resolver_vantages}) != _RESOLVER_VANTAGE_COUNT
     ):
         raise ValueError('DNS validation requires exactly three distinct resolver vantages')
+    base_result = base_result or begin_run(target)
     normalized_target = _normalize_hostname(target)
-    run_id = str(uuid4())
-    started_at = datetime.now(UTC)
+    if base_result.target != normalized_target:
+        raise ValueError('base run target does not match source target')
+    run_id = base_result.run_id
+    started_at = base_result.started_at
     started = time.perf_counter()
     observations: tuple[DiscoveryObservation, ...] = ()
     status = SourceStatus.FAILED
@@ -556,6 +658,7 @@ async def execute_run(
                 derivation=finding.derivation,
                 collected_at=collected_at,
                 scope_class=_classify_scope(normalized_target, value, finding.derivation),
+                provider_observed_at=finding.observed_at,
             )
             for finding in findings
         )
@@ -567,8 +670,9 @@ async def execute_run(
     except Exception as error:
         error_type = type(error).__name__
 
+    observations = (*base_result.observations, *observations)
     entities = _merge_observations(observations)
-    dns_validations: tuple[DNSValidationObservation, ...] = ()
+    dns_validations = base_result.dns_validations
     if resolver_vantages is not None:
         dns_validations, entities = await _validate_entities(run_id, normalized_target, entities, resolver_vantages)
     execution = SourceExecution(
@@ -587,12 +691,13 @@ async def execute_run(
         target=normalized_target,
         started_at=started_at,
         completed_at=datetime.now(UTC),
-        source_executions=(execution,),
+        source_executions=(*base_result.source_executions, execution),
         observations=observations,
         dns_validations=dns_validations,
         entities=entities,
     )
-    await (store or SQLiteRunStore()).save(result)
+    if persist:
+        await (store or SQLiteRunStore()).save(result)
     return result
 
 
@@ -603,4 +708,117 @@ def legacy_hostnames(result: RunResult) -> list[str]:
         for entity in result.entities
         if ScopeClass.IN_SCOPE in entity.scope_classes
         and (entity.addressability is Addressability.CURRENT or not result.dns_validations)
+    )
+
+
+def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -> RunResult:
+    """Merge selected stage results once and close the run."""
+    collected_at = datetime.now(UTC)
+    collected_findings = tuple((stage, finding) for stage in stage_results for finding in dict.fromkeys(stage.findings))
+    existing_observations = {
+        (observation.source, observation.value, observation.derivation) for observation in result.observations
+    }
+    added_observations = tuple(
+        DiscoveryObservation(
+            run_id=result.run_id,
+            target=result.target,
+            value=(value := _normalize_hostname(finding.value.split(':', 1)[0])),
+            source=stage.source,
+            source_family=stage.source_family or stage.source,
+            derivation=finding.derivation,
+            collected_at=collected_at,
+            scope_class=_classify_scope(result.target, value, finding.derivation),
+        )
+        for stage, finding in collected_findings
+        if finding.kind is StageFindingKind.HOSTNAME
+        and (
+            stage.source,
+            _normalize_hostname(finding.value.split(':', 1)[0]),
+            finding.derivation,
+        )
+        not in existing_observations
+    )
+    merged = _merge_observations((*result.observations, *added_observations))
+    previous_entities = {entity.value: entity for entity in result.entities}
+    entities = tuple(
+        replace(
+            entity,
+            addressability=previous.addressability,
+            dns_validations=previous.dns_validations,
+        )
+        if (previous := previous_entities.get(entity.value)) is not None
+        else entity
+        for entity in merged
+    )
+    selected_observations = tuple(
+        SelectedObservation(
+            run_id=result.run_id,
+            source=stage.source,
+            kind=finding.kind,
+            value=finding.value,
+            detail=finding.detail,
+            derivation=finding.derivation,
+            collected_at=collected_at,
+        )
+        for stage, finding in collected_findings
+        if finding.kind is not StageFindingKind.HOSTNAME
+    )
+    executions = list(result.source_executions)
+    executed_sources = {execution.source.casefold() for execution in executions}
+    for stage in stage_results:
+        if stage.source.casefold() in executed_sources:
+            continue
+        unique_stage_findings = tuple(dict.fromkeys(stage.findings))
+        executions.append(
+            SourceExecution(
+                run_id=result.run_id,
+                source=stage.source,
+                source_family=stage.source_family or stage.source,
+                status=stage.status,
+                duration_ms=stage.duration_ms,
+                result_count=stage.result_count,
+                observation_count=len(unique_stage_findings),
+                entity_count=len(
+                    {
+                        _normalize_hostname(finding.value.split(':', 1)[0])
+                        for finding in unique_stage_findings
+                        if finding.kind is StageFindingKind.HOSTNAME
+                    }
+                ),
+                error_type=stage.error_type,
+            )
+        )
+        executed_sources.add(stage.source.casefold())
+    return replace(
+        result,
+        completed_at=datetime.now(UTC),
+        source_executions=tuple(executions),
+        observations=(*result.observations, *added_observations),
+        entities=entities,
+        selected_observations=(*result.selected_observations, *selected_observations),
+    )
+
+
+async def validate_unvalidated_entities(
+    result: RunResult,
+    resolver_vantages: Sequence[ResolverVantage],
+) -> RunResult:
+    """Validate merged in-scope entities that do not yet carry DNS evidence."""
+    unvalidated = tuple(
+        entity for entity in result.entities if ScopeClass.IN_SCOPE in entity.scope_classes and not entity.dns_validations
+    )
+    if not unvalidated:
+        return result
+    validations, validated = await _validate_entities(
+        result.run_id,
+        result.target,
+        unvalidated,
+        resolver_vantages,
+    )
+    validated_by_value = {entity.value: entity for entity in validated}
+    return replace(
+        result,
+        completed_at=datetime.now(UTC),
+        dns_validations=(*result.dns_validations, *validations),
+        entities=tuple(validated_by_value.get(entity.value, entity) for entity in result.entities),
     )

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import ipaddress
 import json
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
@@ -15,7 +16,7 @@ import aiodns
 import aiosqlite
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
 
 class Derivation(StrEnum):
@@ -87,6 +88,31 @@ class StageFinding:
     value: str
     detail: str | None = None
     derivation: Derivation = Derivation.PROVIDER
+    attributes: dict[str, object] | None = field(default=None, hash=False)
+
+
+def person_stage_finding(person: Mapping[str, object]) -> StageFinding | None:
+    allowed_attributes = (
+        'email',
+        'firstname',
+        'lastname',
+        'company',
+        'role',
+        'job_title',
+        'department',
+        'industry',
+        'city',
+        'state',
+        'country',
+    )
+    attributes = {key: person[key] for key in allowed_attributes if key in person}
+    if not attributes:
+        return None
+    return StageFinding(
+        StageFindingKind.PERSON,
+        '',
+        attributes=attributes,
+    )
 
 
 @dataclass(frozen=True)
@@ -109,9 +135,10 @@ class SelectedObservation:
     detail: str | None
     derivation: Derivation
     collected_at: datetime
+    attributes: dict[str, object] | None = None
 
-    def to_dict(self) -> dict[str, str | None]:
-        return {
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {
             'run_id': self.run_id,
             'source': self.source,
             'kind': self.kind,
@@ -120,6 +147,22 @@ class SelectedObservation:
             'derivation': self.derivation,
             'collected_at': self.collected_at.isoformat(),
         }
+        if self.attributes is not None:
+            result['attributes'] = self.attributes
+        return result
+
+
+def _person_identity(attributes: dict[str, object]) -> str:
+    email = attributes.get('email')
+    if isinstance(email, str) and (email := email.strip()):
+        return email
+    name = ' '.join(
+        value.strip() for key in ('firstname', 'lastname') if isinstance((value := attributes.get(key)), str) and value.strip()
+    )
+    if name:
+        return name
+    serialized = json.dumps(attributes, ensure_ascii=False, separators=(',', ':'), sort_keys=True)
+    return f'person-{hashlib.sha256(serialized.encode()).hexdigest()[:12]}'
 
 
 class PassiveSource(Protocol):
@@ -670,6 +713,8 @@ async def execute_run(
     except Exception as error:
         error_type = type(error).__name__
 
+    source_observation_count = len(observations)
+    source_entity_count = len({observation.value for observation in observations})
     observations = (*base_result.observations, *observations)
     entities = _merge_observations(observations)
     dns_validations = base_result.dns_validations
@@ -682,8 +727,8 @@ async def execute_run(
         status=status,
         duration_ms=(time.perf_counter() - started) * 1000,
         result_count=result_count,
-        observation_count=len(observations),
-        entity_count=len(entities),
+        observation_count=source_observation_count,
+        entity_count=source_entity_count,
         error_type=error_type,
     )
     result = RunResult(
@@ -755,10 +800,15 @@ def complete_run(result: RunResult, stage_results: Sequence[StageResult] = ()) -
             run_id=result.run_id,
             source=stage.source,
             kind=finding.kind,
-            value=finding.value,
+            value=(
+                _person_identity(finding.attributes)
+                if finding.kind is StageFindingKind.PERSON and finding.attributes is not None
+                else finding.value
+            ),
             detail=finding.detail,
             derivation=finding.derivation,
             collected_at=collected_at,
+            attributes=dict(finding.attributes) if finding.attributes is not None else None,
         )
         for stage, finding in collected_findings
         if finding.kind is not StageFindingKind.HOSTNAME


### PR DESCRIPTION
## Summary

- produce one completed evidence-bearing run across CLI and REST paths
- adapt output and persistence from that completed run
- emit versioned normalized JSONL alongside the existing XML and legacy JSON reports
- make every JSONL line independently correlatable with top-level `run_id` and `target`
- report per-source observation and entity counts instead of cumulative run counts
- preserve curated Shodan enrichment as structured JSONL attributes
- preserve useful Venacus person fields as structured attributes while excluding phone numbers, addresses, ZIP codes, dates of birth, passwords, and records containing only excluded fields

## Stack

Depends on `codex/dns-consensus`. This remains one atomic vertical slice across run orchestration, output, API, and persistence.

## Validation

- focused completed-output and run suites: 30 passed
- safe suite: 157 passed, 4 skipped, 3 explicitly deselected environment-dependent tests
- `ruff check` and `ruff format --check` on changed files
- `mypy theHarvester`
- standards and spec reviews found no remaining issues

The three excluded tests are two live-provider tests and one test that writes to the default local SQLite path. Legacy JSON and XML behavior remains compatible. JSONL contains normalized entities and curated structured attributes, not raw API responses.
