### PR TITLE
Classify candidates with DNS consensus

### DIFF
--- a/tests/lib/test_run.py
+++ b/tests/lib/test_run.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -7,7 +8,9 @@ import pytest
 
 from theHarvester.lib.run import (
     Addressability,
+    AioDNSResolverVantage,
     Derivation,
+    DNSResponse,
     ScopeClass,
     SourceFinding,
     SourceRateLimitedError,
@@ -19,6 +22,7 @@ from theHarvester.lib.run import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 
@@ -35,6 +39,335 @@ class FakePassiveSource:
             SourceFinding('example.com.evil.test', Derivation.RELATED),
             SourceFinding('cdn.vendor.test', Derivation.EXTERNAL_RELATIONSHIP),
         ]
+
+
+class OneCandidateSource:
+    name = 'fixture'
+    family = 'fixture-family'
+
+    def __init__(self, candidate: str) -> None:
+        self.candidate = candidate
+
+    async def collect(self, _target: str) -> list[SourceFinding]:
+        return [SourceFinding(self.candidate)]
+
+
+class FakeResolverVantage:
+    def __init__(self, name: str, candidate: str, response: DNSResponse) -> None:
+        self.name = name
+        self.candidate = candidate
+        self.response = response
+
+    async def query(self, hostname: str) -> DNSResponse:
+        if hostname == self.candidate:
+            return self.response
+        return DNSResponse(rcode='NXDOMAIN')
+
+
+class RuleResolverVantage:
+    def __init__(self, name: str, handler: Callable[[str], DNSResponse]) -> None:
+        self.name = name
+        self.handler = handler
+
+    async def query(self, hostname: str) -> DNSResponse:
+        return self.handler(hostname)
+
+
+class RotatingResolverVantage:
+    def __init__(
+        self,
+        name: str,
+        candidate: str,
+        candidate_response: DNSResponse,
+        control_responses: tuple[DNSResponse, ...],
+    ) -> None:
+        self.name = name
+        self.candidate = candidate
+        self.candidate_response = candidate_response
+        self.control_responses = control_responses
+        self.control_index = 0
+
+    async def query(self, hostname: str) -> DNSResponse:
+        if hostname == self.candidate:
+            return self.candidate_response
+        response = self.control_responses[self.control_index % len(self.control_responses)]
+        self.control_index += 1
+        return response
+
+
+@pytest.mark.asyncio
+async def test_execute_run_records_dns_consensus_without_requiring_identical_addresses(tmp_path: Path) -> None:
+    candidate = 'api.example.com'
+    resolvers = (
+        FakeResolverVantage(
+            'resolver-a',
+            candidate,
+            DNSResponse(
+                ipv4=('192.0.2.10',),
+                cnames=('Edge.Example.NET.',),
+                rcode='NOERROR',
+                ttl=300,
+                cname_chain=('Edge.Example.NET.',),
+            ),
+        ),
+        FakeResolverVantage(
+            'resolver-b',
+            candidate,
+            DNSResponse(ipv6=('2001:0db8::10',), rcode='NOERROR', ttl=120),
+        ),
+        FakeResolverVantage('resolver-c', candidate, DNSResponse(rcode='NXDOMAIN', ttl=60)),
+    )
+
+    result = await execute_run(
+        'example.com',
+        OneCandidateSource(candidate),
+        resolver_vantages=resolvers,
+        store=SQLiteRunStore(tmp_path / 'evidence.sqlite'),
+    )
+
+    entity = result.entities[0]
+    candidate_observations = [item for item in result.dns_validations if not item.is_wildcard_control]
+    assert entity.addressability is Addressability.CURRENT
+    assert entity.dns_validations[:3] == tuple(candidate_observations)
+    assert len(candidate_observations) == 3
+    assert candidate_observations[0].candidate == candidate
+    assert candidate_observations[0].query_name == candidate
+    assert candidate_observations[0].resolver == 'resolver-a'
+    assert candidate_observations[0].ipv4 == ('192.0.2.10',)
+    assert candidate_observations[0].cnames == ('edge.example.net',)
+    assert candidate_observations[0].rcode == 'NOERROR'
+    assert candidate_observations[0].ttl == 300
+    assert candidate_observations[0].cname_chain == ('edge.example.net',)
+    assert candidate_observations[0].queried_at.tzinfo is not None
+    assert candidate_observations[0].latency_ms >= 0
+    assert candidate_observations[0].error is None
+    assert candidate_observations[1].ipv6 == ('2001:db8::10',)
+
+
+@pytest.mark.asyncio
+async def test_execute_run_keeps_resolver_disagreement_as_secondary_evidence(tmp_path: Path) -> None:
+    candidate = 'api.example.com'
+    resolvers = (
+        FakeResolverVantage('resolver-a', candidate, DNSResponse(ipv4=('192.0.2.10',))),
+        FakeResolverVantage('resolver-b', candidate, DNSResponse(rcode='NXDOMAIN')),
+        FakeResolverVantage('resolver-c', candidate, DNSResponse(rcode='ERROR', error='timeout')),
+    )
+
+    result = await execute_run(
+        'example.com',
+        OneCandidateSource(candidate),
+        resolver_vantages=resolvers,
+        store=SQLiteRunStore(tmp_path / 'evidence.sqlite'),
+    )
+
+    assert result.entities[0].addressability is Addressability.RESOLVER_DISPUTED
+    assert legacy_hostnames(result) == []
+    assert len(result.observations) == 1
+    assert result.observations[0].value == candidate
+    assert len([item for item in result.dns_validations if not item.is_wildcard_control]) == 3
+
+
+@pytest.mark.asyncio
+async def test_execute_run_detects_nested_wildcards_without_promoting_control_names(tmp_path: Path) -> None:
+    candidate = 'api.dev.example.com'
+
+    def nested_wildcard(hostname: str) -> DNSResponse:
+        if hostname == candidate or hostname.endswith('.dev.example.com'):
+            return DNSResponse(ipv4=('192.0.2.20',), ttl=30)
+        return DNSResponse(rcode='NXDOMAIN')
+
+    result = await execute_run(
+        'example.com',
+        OneCandidateSource(candidate),
+        resolver_vantages=tuple(RuleResolverVantage(f'resolver-{suffix}', nested_wildcard) for suffix in ('a', 'b', 'c')),
+        store=SQLiteRunStore(tmp_path / 'evidence.sqlite'),
+    )
+
+    controls = [item for item in result.dns_validations if item.is_wildcard_control]
+    controls_by_name: dict[str, list[str]] = {}
+    for control in controls:
+        controls_by_name.setdefault(control.query_name, []).append(control.resolver)
+    assert result.entities[0].addressability is Addressability.WILDCARD_UNCERTAIN
+    assert {item.wildcard_depth for item in controls} == {'example.com', 'dev.example.com'}
+    assert len(controls_by_name) == 6
+    assert all(len(resolvers) == 3 for resolvers in controls_by_name.values())
+    assert [item.value for item in result.observations] == [candidate]
+    assert [item.value for item in result.entities] == [candidate]
+
+
+@pytest.mark.asyncio
+async def test_execute_run_respects_empty_non_terminal_exact_overrides(tmp_path: Path) -> None:
+    candidate = 'api.empty.example.com'
+
+    def exact_below_empty_non_terminal(hostname: str) -> DNSResponse:
+        if hostname == candidate:
+            return DNSResponse(ipv4=('192.0.2.10',))
+        if hostname.endswith('.empty.example.com'):
+            return DNSResponse(rcode='NXDOMAIN')
+        return DNSResponse(ipv4=('192.0.2.10',))
+
+    result = await execute_run(
+        'example.com',
+        OneCandidateSource(candidate),
+        resolver_vantages=tuple(
+            RuleResolverVantage(f'resolver-{suffix}', exact_below_empty_non_terminal) for suffix in ('a', 'b', 'c')
+        ),
+        store=SQLiteRunStore(tmp_path / 'evidence.sqlite'),
+    )
+
+    assert result.entities[0].addressability is Addressability.CURRENT
+
+
+@pytest.mark.asyncio
+async def test_execute_run_detects_rotating_root_wildcard_cname_on_any_vantage(tmp_path: Path) -> None:
+    candidate = 'www.example.com'
+    resolvers = (
+        RotatingResolverVantage(
+            'resolver-a',
+            candidate,
+            DNSResponse(ipv4=('192.0.2.90',)),
+            (
+                DNSResponse(ipv4=('192.0.2.1',)),
+                DNSResponse(ipv6=('2001:db8::1',)),
+                DNSResponse(cnames=('other.example.net',)),
+            ),
+        ),
+        RotatingResolverVantage(
+            'resolver-b',
+            candidate,
+            DNSResponse(ipv4=('192.0.2.91',), cnames=('exact.example.net',)),
+            (
+                DNSResponse(ipv4=('192.0.2.2',)),
+                DNSResponse(ipv6=('2001:0db8::2',)),
+                DNSResponse(cnames=('wildcard.example.net',)),
+            ),
+        ),
+        RotatingResolverVantage(
+            'resolver-c',
+            candidate,
+            DNSResponse(ipv4=('192.0.2.92',)),
+            (
+                DNSResponse(ipv4=('192.0.2.3',)),
+                DNSResponse(ipv6=('2001:db8::3',)),
+                DNSResponse(cnames=('third.example.net',)),
+            ),
+        ),
+    )
+
+    result = await execute_run(
+        'example.com',
+        OneCandidateSource(candidate),
+        resolver_vantages=resolvers,
+        store=SQLiteRunStore(tmp_path / 'evidence.sqlite'),
+    )
+
+    controls = [item for item in result.dns_validations if item.is_wildcard_control]
+    assert result.entities[0].addressability is Addressability.WILDCARD_UNCERTAIN
+    assert {address for item in controls for address in item.ipv4} >= {'192.0.2.1', '192.0.2.2', '192.0.2.3'}
+    assert {address for item in controls for address in item.ipv6} >= {
+        '2001:db8::1',
+        '2001:db8::2',
+        '2001:db8::3',
+    }
+    assert 'wildcard.example.net' in {cname for item in controls for cname in item.cnames}
+
+
+@pytest.mark.asyncio
+async def test_aiodns_vantage_follows_and_normalizes_multi_hop_cname_chain(monkeypatch: pytest.MonkeyPatch) -> None:
+    import theHarvester.lib.run as run_module
+
+    closed: list[bool] = []
+    aliases = {
+        'alias.example.com': ('Edge.Example.NET.', 90),
+        'edge.example.net': ('Origin.Example.NET.', 60),
+    }
+
+    class FakeDNSResolver:
+        def __init__(self, *, nameservers: list[str]) -> None:
+            assert nameservers == ['192.0.2.53']
+
+        async def query_dns(self, hostname: str, record_type: str):
+            if record_type == 'CNAME' and hostname in aliases:
+                cname, ttl = aliases[hostname]
+                return SimpleNamespace(answer=[SimpleNamespace(ttl=ttl, data=SimpleNamespace(cname=cname))])
+            if record_type == 'A' and hostname == 'origin.example.net':
+                return SimpleNamespace(answer=[SimpleNamespace(ttl=30, data=SimpleNamespace(addr='192.0.2.10'))])
+            raise run_module.aiodns.error.DNSError(run_module.aiodns.error.ARES_ENODATA, 'no data')
+
+        async def close(self) -> None:
+            closed.append(True)
+
+    monkeypatch.setattr(run_module.aiodns, 'DNSResolver', FakeDNSResolver)
+    vantage = AioDNSResolverVantage('192.0.2.53')
+
+    response = await vantage.query('alias.example.com')
+    await vantage.close()
+
+    assert response.ipv4 == ('192.0.2.10',)
+    assert response.cnames == ('edge.example.net', 'origin.example.net')
+    assert response.cname_chain == ('edge.example.net', 'origin.example.net')
+    assert response.ttl == 30
+    assert response.error is None
+    assert closed == [True]
+
+
+@pytest.mark.asyncio
+async def test_aiodns_vantage_stops_cname_loops(monkeypatch: pytest.MonkeyPatch) -> None:
+    import theHarvester.lib.run as run_module
+
+    aliases = {'loop-a.example.com': 'loop-b.example.com', 'loop-b.example.com': 'loop-a.example.com'}
+    queries: list[tuple[str, str]] = []
+
+    class FakeDNSResolver:
+        def __init__(self, *, nameservers: list[str]) -> None:
+            assert nameservers == ['192.0.2.53']
+
+        async def query_dns(self, hostname: str, record_type: str):
+            queries.append((hostname, record_type))
+            if record_type == 'CNAME':
+                return SimpleNamespace(answer=[SimpleNamespace(ttl=60, data=SimpleNamespace(cname=aliases[hostname]))])
+            raise run_module.aiodns.error.DNSError(run_module.aiodns.error.ARES_ENODATA, 'no data')
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(run_module.aiodns, 'DNSResolver', FakeDNSResolver)
+
+    response = await AioDNSResolverVantage('192.0.2.53').query('loop-a.example.com')
+
+    assert response.cname_chain == ('loop-b.example.com', 'loop-a.example.com')
+    assert response.error == 'CNAME loop detected at loop-a.example.com'
+    assert len(queries) == 6
+
+
+@pytest.mark.asyncio
+async def test_aiodns_vantage_bounds_cname_chain_depth(monkeypatch: pytest.MonkeyPatch) -> None:
+    import theHarvester.lib.run as run_module
+
+    queries: list[tuple[str, str]] = []
+
+    class FakeDNSResolver:
+        def __init__(self, *, nameservers: list[str]) -> None:
+            assert nameservers == ['192.0.2.53']
+
+        async def query_dns(self, hostname: str, record_type: str):
+            queries.append((hostname, record_type))
+            if record_type == 'CNAME':
+                label = int(hostname.removeprefix('node-').removesuffix('.example.com'))
+                cname = f'node-{label + 1}.example.com'
+                return SimpleNamespace(answer=[SimpleNamespace(ttl=60, data=SimpleNamespace(cname=cname))])
+            raise run_module.aiodns.error.DNSError(run_module.aiodns.error.ARES_ENODATA, 'no data')
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(run_module.aiodns, 'DNSResolver', FakeDNSResolver)
+
+    response = await AioDNSResolverVantage('192.0.2.53').query('node-0.example.com')
+
+    assert response.error == 'CNAME chain exceeded 16 links'
+    assert len(response.cname_chain) == 16
+    assert len(queries) == 48
 
 
 @pytest.mark.asyncio
@@ -193,3 +526,196 @@ async def test_crtsh_bridge_executes_once_and_feeds_legacy_consumers(monkeypatch
     assert legacy_hostnames(captured[0]) == ['www.example.com']
     assert await evidence_store.load(captured[0].run_id) == captured[0].to_dict()
     assert stored == [('example.com', ('www.example.com',), 'host', 'CRTsh')]
+
+
+@pytest.mark.parametrize(
+    'dns_resolve',
+    [None, '192.0.2.53', '192.0.2.53,192.0.2.54', '192.0.2.53,192.0.2.54,192.0.2.55,192.0.2.56'],
+)
+@pytest.mark.asyncio
+async def test_start_rejects_explicit_resolver_counts_other_than_three(
+    dns_resolve: str | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import argparse
+
+    import theHarvester.__main__ as main_module
+
+    class NoNetworkCrtshSearch:
+        def __init__(self, target: str) -> None:
+            assert target == 'example.com'
+
+        async def process(self, _proxy: bool = False) -> None:
+            raise AssertionError('invalid resolver policy must fail before source execution')
+
+        async def get_hostnames(self) -> list[str]:
+            return []
+
+    monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', NoNetworkCrtshSearch)
+
+    with pytest.raises(ValueError, match='exactly three distinct resolver vantages'):
+        await main_module.start(
+            argparse.Namespace(
+                api_scan=False,
+                dns_brute=False,
+                dns_lookup=False,
+                dns_resolve=dns_resolve,
+                dns_server=None,
+                domain='example.com',
+                filename='',
+                limit=500,
+                proxies=False,
+                quiet=True,
+                shodan=False,
+                source='crtsh',
+                start=0,
+                take_over=False,
+                wordlist='',
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_crtsh_bridge_closes_constructed_vantages_after_partial_constructor_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import argparse
+
+    import theHarvester.__main__ as main_module
+
+    class FakeCrtshSearch:
+        def __init__(self, target: str) -> None:
+            assert target == 'example.com'
+
+    attempted: list[str] = []
+    closed: list[str] = []
+
+    class PartiallyFailingVantage:
+        def __init__(self, nameserver: str) -> None:
+            attempted.append(nameserver)
+            if len(attempted) == 2:
+                raise RuntimeError('resolver construction failed')
+            self.name = nameserver
+
+        async def close(self) -> None:
+            closed.append(self.name)
+
+    monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
+    monkeypatch.setattr(main_module, 'AioDNSResolverVantage', PartiallyFailingVantage, raising=True)
+
+    await main_module.start(
+        argparse.Namespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='192.0.2.53,192.0.2.54,192.0.2.55',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=True,
+            shodan=False,
+            source='crtsh',
+            start=0,
+            take_over=False,
+            wordlist='',
+        )
+    )
+
+    assert len(attempted) == 2
+    assert closed == [attempted[0]]
+
+
+@pytest.mark.asyncio
+async def test_crtsh_bridge_uses_three_explicit_resolver_vantages(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import argparse
+
+    import theHarvester.__main__ as main_module
+    import theHarvester.lib.run as run_module
+
+    class FakeCrtshSearch:
+        def __init__(self, target: str) -> None:
+            assert target == 'example.com'
+
+        async def process(self, proxy: bool = False) -> None:
+            assert proxy is False
+
+        async def get_hostnames(self) -> list[str]:
+            return ['www.example.com']
+
+    created: list[str] = []
+    closed: list[str] = []
+
+    class FakeProductionVantage:
+        def __init__(self, nameserver: str) -> None:
+            self.name = nameserver
+            created.append(nameserver)
+
+        async def query(self, hostname: str) -> DNSResponse:
+            return DNSResponse(ipv4=('192.0.2.10',)) if hostname == 'www.example.com' else DNSResponse(rcode='NXDOMAIN')
+
+        async def close(self) -> None:
+            closed.append(self.name)
+
+    class FakeHostChecker:
+        def __init__(self, hosts: list[str], nameservers: list[str]) -> None:
+            assert hosts == ['www.example.com']
+            assert set(nameservers) == {'192.0.2.53', '192.0.2.54', '192.0.2.55'}
+
+        async def check(self) -> tuple[list[str], list[str], list[str]]:
+            return ['www.example.com:192.0.2.10'], ['www.example.com'], ['192.0.2.10']
+
+    class FakeStashManager:
+        async def do_init(self) -> None:
+            return None
+
+        async def store_all(self, _domain: str, _items: list[str], _result_type: str, _source: str) -> None:
+            return None
+
+    evidence_store = SQLiteRunStore(tmp_path / 'evidence.sqlite')
+    captured: list[run_module.RunResult] = []
+
+    async def execute_with_temporary_store(
+        target: str,
+        source: run_module.PassiveSource,
+        *,
+        resolver_vantages: tuple[run_module.ResolverVantage, ...] | None = None,
+    ) -> run_module.RunResult:
+        result = await run_module.execute_run(
+            target,
+            source,
+            resolver_vantages=resolver_vantages,
+            store=evidence_store,
+        )
+        captured.append(result)
+        return result
+
+    monkeypatch.setattr(main_module.crtsh, 'SearchCrtsh', FakeCrtshSearch)
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(main_module.hostchecker, 'Checker', FakeHostChecker)
+    monkeypatch.setattr(main_module, 'AioDNSResolverVantage', FakeProductionVantage, raising=True)
+    monkeypatch.setattr(main_module, 'execute_run', execute_with_temporary_store, raising=True)
+
+    await main_module.start(
+        argparse.Namespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='192.0.2.53,192.0.2.54,192.0.2.55',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=500,
+            proxies=False,
+            quiet=True,
+            shodan=False,
+            source='crtsh',
+            start=0,
+            take_over=False,
+            wordlist='',
+        )
+    )
+
+    assert set(created) == {'192.0.2.53', '192.0.2.54', '192.0.2.55'}
+    assert set(closed) == set(created)
+    assert captured[0].entities[0].addressability is Addressability.CURRENT

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -8,6 +8,7 @@ import sys
 import time
 import traceback
 from collections.abc import Awaitable
+from contextlib import AsyncExitStack
 from typing import Any
 
 import anyio
@@ -79,7 +80,7 @@ from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib import hostchecker, stash
 from theHarvester.lib.core import DATA_DIR, Core, show_default_error_message
 from theHarvester.lib.output import print_linkedin_sections, print_section, sorted_unique
-from theHarvester.lib.run import LegacyHostnameSource, execute_run, legacy_hostnames
+from theHarvester.lib.run import AioDNSResolverVantage, LegacyHostnameSource, execute_run, legacy_hostnames
 from theHarvester.lib.source_catalog import SourceSchedule, canonical_source_names, describe_activity, resolve_sources
 from theHarvester.screenshot.screenshot import ScreenShotter
 
@@ -320,8 +321,12 @@ async def start(rest_args: argparse.Namespace | None = None):
 
         # if for some reason, there are duplicates
         final_dns_resolver_list = list(set(final_dns_resolver_list))
-        if len(final_dns_resolver_list) == 0:
-            print('No valid DNS resolvers were parsed from --dns-resolve; continuing without custom resolvers.')
+    if dnsresolve != '' and len(final_dns_resolver_list) != 3:
+        resolver_error = ValueError('--dns-resolve requires exactly three distinct resolver vantages')
+        if rest_args is not None:
+            raise resolver_error
+        print(f'\n[!] {resolver_error}.\n')
+        sys.exit(1)
 
     engines: list = []
     # If the user specifies
@@ -389,7 +394,16 @@ async def start(rest_args: argparse.Namespace | None = None):
                 else await search_engine.process(process_param, use_proxy)
             )
         else:
-            run_result = await execute_run(word, evidence_source)
+            if len(final_dns_resolver_list) == 3:
+                resolver_vantages: list[AioDNSResolverVantage] = []
+                async with AsyncExitStack() as resolver_stack:
+                    for nameserver in final_dns_resolver_list:
+                        resolver = AioDNSResolverVantage(nameserver)
+                        resolver_vantages.append(resolver)
+                        resolver_stack.push_async_callback(resolver.close)
+                    run_result = await execute_run(word, evidence_source, resolver_vantages=resolver_vantages)
+            else:
+                run_result = await execute_run(word, evidence_source)
         db_stash = stash.StashManager()
 
         if source:

--- a/theHarvester/lib/run.py
+++ b/theHarvester/lib/run.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import asyncio
+import ipaddress
 import json
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 from uuid import uuid4
 
+import aiodns
 import aiosqlite
 
 if TYPE_CHECKING:
@@ -29,6 +32,10 @@ class ScopeClass(StrEnum):
 
 class Addressability(StrEnum):
     UNVERIFIED = 'unverified'
+    CURRENT = 'currently-addressable'
+    NOT_CURRENT = 'not-currently-addressable'
+    RESOLVER_DISPUTED = 'resolver-disputed'
+    WILDCARD_UNCERTAIN = 'wildcard-uncertain'
 
 
 class SourceStatus(StrEnum):
@@ -61,6 +68,109 @@ class PassiveSource(Protocol):
     def family(self) -> str: ...
 
     async def collect(self, target: str) -> Sequence[SourceFinding]: ...
+
+
+@dataclass(frozen=True)
+class DNSResponse:
+    ipv4: tuple[str, ...] = ()
+    ipv6: tuple[str, ...] = ()
+    cnames: tuple[str, ...] = ()
+    rcode: str = 'NOERROR'
+    ttl: int | None = None
+    cname_chain: tuple[str, ...] = ()
+    error: str | None = None
+
+
+class ResolverVantage(Protocol):
+    @property
+    def name(self) -> str: ...
+
+    async def query(self, hostname: str) -> DNSResponse: ...
+
+
+class AioDNSResolverVantage:
+    """A single operator-selected resolver exposed through the validation boundary."""
+
+    def __init__(self, nameserver: str) -> None:
+        self.name = nameserver
+        self._resolver = aiodns.DNSResolver(nameservers=[nameserver])
+
+    async def query(self, hostname: str) -> DNSResponse:
+        record_types = ('A', 'AAAA', 'CNAME')
+        ipv4: set[str] = set()
+        ipv6: set[str] = set()
+        cnames: list[str] = []
+        ttls: list[int] = []
+        dns_error_codes: list[int] = []
+        errors: list[str] = []
+        successful_query = False
+        current = _normalize_hostname(hostname)
+        seen = {current}
+        for _ in range(_MAX_CNAME_DEPTH):
+            results = await asyncio.gather(
+                *(self._resolver.query_dns(current, record_type) for record_type in record_types),
+                return_exceptions=True,
+            )
+            next_cnames: list[str] = []
+            for result in results:
+                if isinstance(result, asyncio.CancelledError):
+                    raise result
+                if isinstance(result, BaseException):
+                    if isinstance(result, aiodns.error.DNSError):
+                        dns_error_codes.append(result.args[0])
+                        if result.args[0] in {aiodns.error.ARES_ENOTFOUND, aiodns.error.ARES_ENODATA}:
+                            continue
+                    errors.append(f'{type(result).__name__}: {result}')
+                    continue
+                successful_query = True
+                for record in result.answer:
+                    ttl = getattr(record, 'ttl', None)
+                    if ttl is not None:
+                        ttls.append(ttl)
+                    address = getattr(record.data, 'addr', None)
+                    if address is not None:
+                        parsed_address = ipaddress.ip_address(address)
+                        (ipv4 if parsed_address.version == 4 else ipv6).add(str(parsed_address))
+                    cname = getattr(record.data, 'cname', None)
+                    if cname is not None:
+                        normalized_cname = _normalize_hostname(cname)
+                        if normalized_cname not in next_cnames:
+                            next_cnames.append(normalized_cname)
+            if not next_cnames:
+                break
+            for cname in next_cnames:
+                if cname not in cnames:
+                    cnames.append(cname)
+            next_target = next_cnames[-1]
+            if next_target in seen:
+                errors.append(f'CNAME loop detected at {next_target}')
+                break
+            seen.add(next_target)
+            current = next_target
+        else:
+            errors.append(f'CNAME chain exceeded {_MAX_CNAME_DEPTH} links')
+        if successful_query:
+            rcode = 'NOERROR'
+        elif dns_error_codes and all(code == aiodns.error.ARES_ENOTFOUND for code in dns_error_codes):
+            rcode = 'NXDOMAIN'
+        elif dns_error_codes and all(
+            code in {aiodns.error.ARES_ENOTFOUND, aiodns.error.ARES_ENODATA} for code in dns_error_codes
+        ):
+            rcode = 'NODATA'
+        else:
+            rcode = 'ERROR'
+        return DNSResponse(
+            ipv4=tuple(ipv4),
+            ipv6=tuple(ipv6),
+            cnames=tuple(cnames),
+            rcode=rcode,
+            ttl=min(ttls, default=None),
+            cname_chain=tuple(cnames),
+            error='; '.join(errors) or None,
+        )
+
+    async def close(self) -> None:
+        await self._resolver.close()
 
 
 class LegacyHostnameSearch(Protocol):
@@ -106,6 +216,44 @@ class DiscoveryObservation:
 
 
 @dataclass(frozen=True)
+class DNSValidationObservation:
+    run_id: str
+    candidate: str
+    query_name: str
+    resolver: str
+    queried_at: datetime
+    ipv4: tuple[str, ...]
+    ipv6: tuple[str, ...]
+    cnames: tuple[str, ...]
+    rcode: str
+    ttl: int | None
+    cname_chain: tuple[str, ...]
+    latency_ms: float
+    error: str | None
+    is_wildcard_control: bool = False
+    wildcard_depth: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            'run_id': self.run_id,
+            'candidate': self.candidate,
+            'query_name': self.query_name,
+            'resolver': self.resolver,
+            'queried_at': self.queried_at.isoformat(),
+            'ipv4': list(self.ipv4),
+            'ipv6': list(self.ipv6),
+            'cnames': list(self.cnames),
+            'rcode': self.rcode,
+            'ttl': self.ttl,
+            'cname_chain': list(self.cname_chain),
+            'latency_ms': self.latency_ms,
+            'error': self.error,
+            'is_wildcard_control': self.is_wildcard_control,
+            'wildcard_depth': self.wildcard_depth,
+        }
+
+
+@dataclass(frozen=True)
 class SourceExecution:
     run_id: str
     source: str
@@ -136,6 +284,7 @@ class MergedEntity:
     value: str
     observations: tuple[DiscoveryObservation, ...]
     addressability: Addressability = Addressability.UNVERIFIED
+    dns_validations: tuple[DNSValidationObservation, ...] = ()
 
     @property
     def scope_classes(self) -> tuple[ScopeClass, ...]:
@@ -152,6 +301,7 @@ class MergedEntity:
             'scope_classes': list(self.scope_classes),
             'independent_corroboration_count': self.independent_corroboration_count,
             'observations': [observation.to_dict() for observation in self.observations],
+            'dns_validations': [observation.to_dict() for observation in self.dns_validations],
         }
 
 
@@ -163,6 +313,7 @@ class RunResult:
     completed_at: datetime
     source_executions: tuple[SourceExecution, ...]
     observations: tuple[DiscoveryObservation, ...]
+    dns_validations: tuple[DNSValidationObservation, ...]
     entities: tuple[MergedEntity, ...]
 
     def to_dict(self) -> dict[str, object]:
@@ -173,6 +324,7 @@ class RunResult:
             'completed_at': self.completed_at.isoformat(),
             'source_executions': [execution.to_dict() for execution in self.source_executions],
             'observations': [observation.to_dict() for observation in self.observations],
+            'dns_validations': [observation.to_dict() for observation in self.dns_validations],
             'entities': [entity.to_dict() for entity in self.entities],
         }
 
@@ -229,12 +381,158 @@ def _merge_observations(observations: Sequence[DiscoveryObservation]) -> tuple[M
     return tuple(MergedEntity(value, tuple(supporting)) for value, supporting in grouped.items())
 
 
+# Initial DNS policy. Keep these together so consented benchmarks can tune them later.
+_RESOLVER_VANTAGE_COUNT = 3
+_RESOLVER_QUORUM = 2
+_WILDCARD_PROBES_PER_DEPTH = 3
+_MAX_CNAME_DEPTH = 16
+
+
+def _normalize_dns_response(response: DNSResponse) -> DNSResponse:
+    return DNSResponse(
+        ipv4=tuple(sorted({str(ipaddress.IPv4Address(value)) for value in response.ipv4})),
+        ipv6=tuple(sorted({str(ipaddress.IPv6Address(value)) for value in response.ipv6})),
+        cnames=tuple(sorted({_normalize_hostname(value) for value in response.cnames})),
+        rcode=response.rcode.upper(),
+        ttl=response.ttl,
+        cname_chain=tuple(_normalize_hostname(value) for value in response.cname_chain),
+        error=response.error,
+    )
+
+
+async def _query_dns(
+    run_id: str,
+    candidate: str,
+    query_name: str,
+    resolver: ResolverVantage,
+    *,
+    wildcard_depth: str | None = None,
+) -> DNSValidationObservation:
+    queried_at = datetime.now(UTC)
+    started = time.perf_counter()
+    try:
+        response = _normalize_dns_response(await resolver.query(query_name))
+    except asyncio.CancelledError:
+        raise
+    except Exception as error:
+        response = DNSResponse(rcode='ERROR', error=f'{type(error).__name__}: {error}')
+    return DNSValidationObservation(
+        run_id=run_id,
+        candidate=candidate,
+        query_name=query_name,
+        resolver=resolver.name,
+        queried_at=queried_at,
+        ipv4=response.ipv4,
+        ipv6=response.ipv6,
+        cnames=response.cnames,
+        rcode=response.rcode,
+        ttl=response.ttl,
+        cname_chain=response.cname_chain,
+        latency_ms=(time.perf_counter() - started) * 1000,
+        error=response.error,
+        is_wildcard_control=wildcard_depth is not None,
+        wildcard_depth=wildcard_depth,
+    )
+
+
+def _wildcard_depths(target: str, candidate: str) -> tuple[str, ...]:
+    target_labels = target.split('.')
+    candidate_labels = candidate.split('.')
+    extra_label_count = len(candidate_labels) - len(target_labels)
+    return (target, *('.'.join(candidate_labels[index:]) for index in range(extra_label_count - 1, 0, -1)))
+
+
+def _has_dns_evidence(observation: DNSValidationObservation) -> bool:
+    return bool(observation.ipv4 or observation.ipv6 or observation.cnames or observation.cname_chain)
+
+
+def _classify_addressability(
+    candidate_observations: Sequence[DNSValidationObservation],
+    controls: Sequence[DNSValidationObservation],
+) -> Addressability:
+    closest_depth = max(
+        (control.wildcard_depth for control in controls if control.wildcard_depth is not None),
+        key=lambda depth: depth.count('.'),
+    )
+    closest_controls = tuple(control for control in controls if control.wildcard_depth == closest_depth)
+    if any(map(_has_dns_evidence, candidate_observations)) and any(map(_has_dns_evidence, closest_controls)):
+        return Addressability.WILDCARD_UNCERTAIN
+    determinate_negative = [
+        observation
+        for observation in candidate_observations
+        if not observation.ipv4
+        and not observation.ipv6
+        and observation.error is None
+        and observation.rcode in {'NOERROR', 'NXDOMAIN', 'NODATA'}
+    ]
+    addressable_count = sum(bool(observation.ipv4 or observation.ipv6) for observation in candidate_observations)
+    not_addressable_count = len(determinate_negative)
+    if addressable_count >= _RESOLVER_QUORUM:
+        return Addressability.CURRENT
+    if not_addressable_count >= _RESOLVER_QUORUM:
+        return Addressability.NOT_CURRENT
+    return Addressability.RESOLVER_DISPUTED
+
+
+async def _validate_entities(
+    run_id: str,
+    target: str,
+    entities: Sequence[MergedEntity],
+    resolvers: Sequence[ResolverVantage],
+) -> tuple[tuple[DNSValidationObservation, ...], tuple[MergedEntity, ...]]:
+    validations: list[DNSValidationObservation] = []
+    validated_entities: list[MergedEntity] = []
+    for entity in entities:
+        if ScopeClass.IN_SCOPE not in entity.scope_classes:
+            validated_entities.append(entity)
+            continue
+        candidate_observations = tuple(
+            await asyncio.gather(*(_query_dns(run_id, entity.value, entity.value, resolver) for resolver in resolvers))
+        )
+        control_queries = tuple(
+            (f'th-{uuid4().hex}.{depth}', depth)
+            for depth in _wildcard_depths(target, entity.value)
+            for _ in range(_WILDCARD_PROBES_PER_DEPTH)
+        )
+        controls = tuple(
+            await asyncio.gather(
+                *(
+                    _query_dns(
+                        run_id,
+                        entity.value,
+                        query_name,
+                        resolver,
+                        wildcard_depth=depth,
+                    )
+                    for query_name, depth in control_queries
+                    for resolver in resolvers
+                )
+            )
+        )
+        entity_validations = candidate_observations + controls
+        validations.extend(entity_validations)
+        validated_entities.append(
+            replace(
+                entity,
+                addressability=_classify_addressability(candidate_observations, controls),
+                dns_validations=entity_validations,
+            )
+        )
+    return tuple(validations), tuple(validated_entities)
+
+
 async def execute_run(
     target: str,
     source: PassiveSource,
     *,
+    resolver_vantages: Sequence[ResolverVantage] | None = None,
     store: SQLiteRunStore | None = None,
 ) -> RunResult:
+    if resolver_vantages is not None and (
+        len(resolver_vantages) != _RESOLVER_VANTAGE_COUNT
+        or len({resolver.name for resolver in resolver_vantages}) != _RESOLVER_VANTAGE_COUNT
+    ):
+        raise ValueError('DNS validation requires exactly three distinct resolver vantages')
     normalized_target = _normalize_hostname(target)
     run_id = str(uuid4())
     started_at = datetime.now(UTC)
@@ -270,6 +568,9 @@ async def execute_run(
         error_type = type(error).__name__
 
     entities = _merge_observations(observations)
+    dns_validations: tuple[DNSValidationObservation, ...] = ()
+    if resolver_vantages is not None:
+        dns_validations, entities = await _validate_entities(run_id, normalized_target, entities, resolver_vantages)
     execution = SourceExecution(
         run_id=run_id,
         source=source.name,
@@ -288,6 +589,7 @@ async def execute_run(
         completed_at=datetime.now(UTC),
         source_executions=(execution,),
         observations=observations,
+        dns_validations=dns_validations,
         entities=entities,
     )
     await (store or SQLiteRunStore()).save(result)
@@ -296,4 +598,9 @@ async def execute_run(
 
 def legacy_hostnames(result: RunResult) -> list[str]:
     """Return the host list consumed by the existing CLI, REST, file, and stash paths."""
-    return sorted(entity.value for entity in result.entities if ScopeClass.IN_SCOPE in entity.scope_classes)
+    return sorted(
+        entity.value
+        for entity in result.entities
+        if ScopeClass.IN_SCOPE in entity.scope_classes
+        and (entity.addressability is Addressability.CURRENT or not result.dns_validations)
+    )


### PR DESCRIPTION
## Summary

- classify discovered candidates using DNS evidence consensus
- keep candidate and verified result classes distinct
- preserve evidence in the scoped run model

## Stack

Depends on `codex/source-catalog`. Review only this PR's one-commit delta.

## Validation

`uv run pytest tests/lib/test_run.py`

Result: 20 passed.

