### PR TITLE
Add an offline discovery-quality benchmark

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,41 @@
+# Discovery quality benchmark
+
+`theHarvester-benchmark` is an offline qualification tool. It scores one completed, normalized evidence JSONL run against supplied synthetic truth and supplied execution accounting. It does not load discovery adapters, contact providers, query DNS, or broaden target scope.
+
+Run it with local inputs:
+
+```console
+theHarvester-benchmark \
+  --run-jsonl completed-run.jsonl \
+  --fixture tests/fixtures/benchmark/truth.fixture \
+  --metadata benchmark-metadata.json \
+  --output benchmark-report.json
+```
+
+The fixture declares a public identifier, expected in-scope names, DNS outcomes, wildcard ancestry, scope-extension evidence, external relationships, synthetic source payload findings, primary currently-addressable truth, bounded known inventory, and known-false names. Fixture names and payloads are inputs only and never appear in the report.
+
+Execution metadata must declare:
+
+- the benchmark arm's public identifier;
+- selected sources and selected actions;
+- provider availability;
+- observed provider-request and DNS-query counts;
+- declared cost in integer microunits;
+- declared numeric settings and the settings actually applied; and
+- request, DNS-query, runtime, and cost budgets.
+
+Numeric settings are named evidence rather than benchmark constants. Arms may vary resolver, quorum, wildcard-probe, query, recursion, QPS, runtime, and futility settings. A run fails qualification if its declared and effective settings differ. A comparison is valid only when every arm passed and the arms used the same budget and provider availability.
+
+## Metrics and gates
+
+The sanitized report contains aggregate counts only. It reports unique currently-addressable yield, bounded known-inventory recovery, precision, wildcard false positives, resolver disagreement, out-of-scope promotion, incomplete source statuses, runtime, provider requests, DNS queries, declared cost, source-alone yield, exclusive source contribution, family overlap, combined yield, and distinct-family corroboration.
+
+Qualification fails closed for a fixture DNS or source-payload mismatch, a currently-addressable claim without DNS evidence, a known-false primary result, wildcard false positive, out-of-scope promotion or recursive expansion, an unselected or missing execution, a failed/rate-limited/skipped or otherwise hidden partial run, mismatched declared/effective configuration, unavailable selected providers, accounting mismatch, or a budget overrun. Correlated observations in one source family retain source credit but count as one independent family.
+
+The report deliberately omits the target, run identity, timestamps, entity and query names, resolver names, raw provider payloads, credentials, errors, and evidence excerpts. Input failures also return a generic error without echoing paths or input content.
+
+## From evidence to a fork issue
+
+A correctness fix qualifies for a sanitized fork implementation issue when a deterministic fixture demonstrates a specific invariant repair and the complete gate set shows no safety regression. A yield change qualifies only after repeated incremental currently-addressable-yield gains under equal declared budgets and equivalent provider availability; one showcase run is not enough. Publish only the behavior, aggregate checks, and implementation acceptance criteria to `NotoriousRebel/theHarvester`.
+
+Any separately authorized run against a consented target is opt-in, is executed outside this benchmark command, and keeps its evidence local. Never attach target names, credentials, raw payloads, sensitive evidence, or private research to an implementation issue.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
 [project.scripts]
 theHarvester = "theHarvester.theHarvester:main"
 restfulHarvest = "theHarvester.restfulHarvest:main"
+theHarvester-benchmark = "theHarvester.lib.benchmark:main"
 
 [tool.pytest.ini_options]
 minversion = "8.3.3"

--- a/tests/fixtures/benchmark/truth.fixture
+++ b/tests/fixtures/benchmark/truth.fixture
@@ -1,0 +1,62 @@
+{
+  "fixture_id": "synthetic-v1",
+  "expected_in_scope": [
+    "api.benchmark.test",
+    "ipv6.benchmark.test",
+    "alias.benchmark.test",
+    "disputed.benchmark.test",
+    "ghost.dev.benchmark.test",
+    "nodata.benchmark.test",
+    "missing.benchmark.test"
+  ],
+  "dns_outcomes": {
+    "api.benchmark.test": "currently-addressable",
+    "ipv6.benchmark.test": "currently-addressable",
+    "alias.benchmark.test": "currently-addressable",
+    "disputed.benchmark.test": "resolver-disputed",
+    "ghost.dev.benchmark.test": "wildcard-uncertain",
+    "nodata.benchmark.test": "not-currently-addressable",
+    "missing.benchmark.test": "not-currently-addressable"
+  },
+  "wildcard_ancestry": {
+    "ghost.dev.benchmark.test": "dev.benchmark.test"
+  },
+  "scope_extensions": [
+    "related.example.test"
+  ],
+  "external_relationships": [
+    "cdn.vendor.test"
+  ],
+  "source_payloads": {
+    "fixture-a": [
+      "api.benchmark.test",
+      "alias.benchmark.test",
+      "disputed.benchmark.test",
+      "ghost.dev.benchmark.test",
+      "nodata.benchmark.test",
+      "related.example.test",
+      "cdn.vendor.test"
+    ],
+    "fixture-a-mirror": [
+      "api.benchmark.test",
+      "alias.benchmark.test"
+    ],
+    "fixture-b": [
+      "api.benchmark.test",
+      "ipv6.benchmark.test",
+      "missing.benchmark.test"
+    ]
+  },
+  "primary_truth": [
+    "api.benchmark.test",
+    "ipv6.benchmark.test",
+    "alias.benchmark.test"
+  ],
+  "known_inventory": [
+    "api.benchmark.test",
+    "ipv6.benchmark.test"
+  ],
+  "known_false": [
+    "ghost.dev.benchmark.test"
+  ]
+}

--- a/tests/lib/test_benchmark.py
+++ b/tests/lib/test_benchmark.py
@@ -1,0 +1,627 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from theHarvester.lib.benchmark import (
+    BenchmarkFixture,
+    BenchmarkRunMetadata,
+    compare_benchmarks,
+    evaluate_benchmark,
+    main,
+    serialize_benchmark,
+)
+from theHarvester.lib.output import run_result_jsonl
+from theHarvester.lib.run import (
+    Addressability,
+    Derivation,
+    DiscoveryObservation,
+    DNSResponse,
+    DNSValidationObservation,
+    MergedEntity,
+    RunResult,
+    ScopeClass,
+    SourceFinding,
+    SourceExecution,
+    SourceStatus,
+    execute_run,
+)
+
+
+def _observation(value: str, source: str, family: str, scope: ScopeClass = ScopeClass.IN_SCOPE) -> DiscoveryObservation:
+    return DiscoveryObservation(
+        run_id='fixture-run',
+        target='benchmark.test',
+        value=value,
+        source=source,
+        source_family=family,
+        derivation=Derivation.PROVIDER,
+        collected_at=datetime(2026, 1, 1, tzinfo=UTC),
+        scope_class=scope,
+    )
+
+
+def _execution(source: str, family: str) -> SourceExecution:
+    return SourceExecution(
+        run_id='fixture-run',
+        source=source,
+        source_family=family,
+        status=SourceStatus.SUCCEEDED,
+        duration_ms=10,
+        result_count=1,
+        observation_count=1,
+        entity_count=1,
+    )
+
+
+def _numeric_settings() -> dict[str, int]:
+    return {
+        'resolver_vantages': 3,
+        'resolver_quorum': 2,
+        'wildcard_probes_per_depth': 3,
+        'recursive_depth': 2,
+        'recursive_query_limit': 100,
+        'qps_limit': 20,
+        'runtime_limit_seconds': 5,
+        'futility_zero_yield_batches': 3,
+    }
+
+
+def _validation(candidate: str) -> DNSValidationObservation:
+    return DNSValidationObservation(
+        run_id='fixture-run',
+        candidate=candidate,
+        query_name=candidate,
+        resolver='fixture-resolver',
+        queried_at=datetime(2026, 1, 1, tzinfo=UTC),
+        ipv4=('192.0.2.10',),
+        ipv6=(),
+        cnames=(),
+        rcode='NOERROR',
+        ttl=60,
+        cname_chain=(),
+        latency_ms=1,
+        error=None,
+    )
+
+
+def test_completed_run_is_scored_by_truth_and_distinct_source_families() -> None:
+    api = _observation('api.benchmark.test', 'fixture-a', 'shared-corpus')
+    shared_a = _observation('shared.benchmark.test', 'fixture-a', 'shared-corpus')
+    shared_mirror = _observation('shared.benchmark.test', 'fixture-a-mirror', 'shared-corpus')
+    shared_independent = _observation('shared.benchmark.test', 'fixture-b', 'independent-corpus')
+    disputed = _observation('disputed.benchmark.test', 'fixture-b', 'independent-corpus')
+    api_validation = _validation(api.value)
+    shared_validation = _validation(shared_a.value)
+    started = datetime(2026, 1, 1, tzinfo=UTC)
+    result = RunResult(
+        run_id='fixture-run',
+        target='benchmark.test',
+        started_at=started,
+        completed_at=started + timedelta(milliseconds=250),
+        source_executions=(
+            _execution('fixture-a', 'shared-corpus'),
+            _execution('fixture-a-mirror', 'shared-corpus'),
+            _execution('fixture-b', 'independent-corpus'),
+        ),
+        observations=(api, shared_a, shared_mirror, shared_independent, disputed),
+        dns_validations=(api_validation, shared_validation),
+        entities=(
+            MergedEntity('api.benchmark.test', (api,), Addressability.CURRENT, (api_validation,)),
+            MergedEntity(
+                'shared.benchmark.test',
+                (shared_a, shared_mirror, shared_independent),
+                Addressability.CURRENT,
+                (shared_validation,),
+            ),
+            MergedEntity('disputed.benchmark.test', (disputed,), Addressability.RESOLVER_DISPUTED),
+        ),
+    )
+    fixture = BenchmarkFixture.from_dict(
+        {
+            'fixture_id': 'public-v1',
+            'expected_in_scope': ['api.benchmark.test', 'shared.benchmark.test', 'disputed.benchmark.test'],
+            'dns_outcomes': {
+                'api.benchmark.test': 'currently-addressable',
+                'shared.benchmark.test': 'currently-addressable',
+                'disputed.benchmark.test': 'resolver-disputed',
+            },
+            'wildcard_ancestry': {},
+            'scope_extensions': ['related.example.test'],
+            'external_relationships': ['cdn.example.test'],
+            'source_payloads': {
+                'fixture-a': ['api.benchmark.test', 'shared.benchmark.test'],
+                'fixture-a-mirror': ['shared.benchmark.test'],
+                'fixture-b': ['shared.benchmark.test', 'disputed.benchmark.test'],
+            },
+            'primary_truth': ['api.benchmark.test', 'shared.benchmark.test'],
+            'known_inventory': ['api.benchmark.test', 'shared.benchmark.test'],
+            'known_false': ['wild.benchmark.test'],
+        }
+    )
+    settings = _numeric_settings()
+    metadata = BenchmarkRunMetadata.from_dict(
+        {
+            'arm_id': 'baseline',
+            'selected_sources': ['fixture-a', 'fixture-a-mirror', 'fixture-b'],
+            'selected_actions': ['dns-validation'],
+            'provider_availability': {
+                'fixture-a': True,
+                'fixture-a-mirror': True,
+                'fixture-b': True,
+            },
+            'request_count': 3,
+            'dns_query_count': 2,
+            'declared_cost_microunits': 0,
+            'declared_settings': settings,
+            'effective_settings': settings,
+            'budget': {
+                'request_limit': 10,
+                'dns_query_limit': 100,
+                'runtime_limit_ms': 1000,
+                'cost_limit_microunits': 0,
+            },
+        }
+    )
+
+    report = evaluate_benchmark(result, fixture, metadata)
+
+    assert report['passed'] is True, report
+    assert report['failures'] == []
+    assert report['metrics']['unique_currently_addressable_yield'] == 2
+    assert report['metrics']['known_inventory_recovery'] == {
+        'numerator': 2,
+        'denominator': 2,
+        'ratio': '1.000000',
+    }
+    assert report['metrics']['precision'] == {'numerator': 2, 'denominator': 2, 'ratio': '1.000000'}
+    assert report['metrics']['resolver_disagreement_count'] == 1
+    assert report['metrics']['runtime_ms'] == 250
+    assert report['attribution']['combined_unique_yield'] == 2
+    assert report['attribution']['independent_family_counts'] == {'1': 1, '2': 1}
+    assert report['attribution']['family_overlaps'][0]['yield'] == 1
+    assert all(
+        family.startswith('family-') for family in report['attribution']['family_overlaps'][0]['source_families']
+    )
+    assert sorted(
+        (source['source_alone_yield'], source['exclusive_yield']) for source in report['attribution']['sources']
+    ) == [(1, 0), (1, 0), (2, 1)]
+
+
+def test_safety_completion_configuration_and_budget_gates_fail_closed() -> None:
+    wildcard = _observation('wild.benchmark.test', 'unexpected-source', 'shared-corpus')
+    external = _observation(
+        'outside.example.test',
+        'unexpected-source',
+        'shared-corpus',
+        ScopeClass.SCOPE_EXTENSION,
+    )
+    started = datetime(2026, 1, 1, tzinfo=UTC)
+    result = RunResult(
+        run_id='fixture-run',
+        target='benchmark.test',
+        started_at=started,
+        completed_at=started + timedelta(seconds=2),
+        source_executions=(
+            SourceExecution(
+                run_id='fixture-run',
+                source='unexpected-source',
+                source_family='shared-corpus',
+                status=SourceStatus.FAILED,
+                duration_ms=2000,
+                result_count=2,
+                observation_count=2,
+                entity_count=2,
+                error_type='SyntheticFailure',
+            ),
+        ),
+        observations=(wildcard, external),
+        dns_validations=(),
+        entities=(
+            MergedEntity('wild.benchmark.test', (wildcard,), Addressability.CURRENT),
+            MergedEntity('outside.example.test', (external,), Addressability.CURRENT),
+        ),
+    )
+    fixture = BenchmarkFixture.from_dict(
+        {
+            'fixture_id': 'public-v1',
+            'expected_in_scope': ['good.benchmark.test', 'wild.benchmark.test'],
+            'dns_outcomes': {
+                'good.benchmark.test': 'currently-addressable',
+                'wild.benchmark.test': 'wildcard-uncertain',
+            },
+            'wildcard_ancestry': {'wild.benchmark.test': 'benchmark.test'},
+            'scope_extensions': ['outside.example.test'],
+            'external_relationships': ['cdn.example.test'],
+            'source_payloads': {'expected-source': ['good.benchmark.test']},
+            'primary_truth': ['good.benchmark.test'],
+            'known_inventory': ['good.benchmark.test'],
+            'known_false': ['wild.benchmark.test'],
+        }
+    )
+    metadata = BenchmarkRunMetadata.from_dict(
+        {
+            'arm_id': 'candidate',
+            'selected_sources': ['expected-source'],
+            'selected_actions': [],
+            'provider_availability': {'expected-source': False},
+            'request_count': 11,
+            'dns_query_count': 2,
+            'declared_cost_microunits': 2,
+            'declared_settings': {'resolver_quorum': 2},
+            'effective_settings': {'resolver_quorum': 1},
+            'budget': {
+                'request_limit': 10,
+                'dns_query_limit': 1,
+                'runtime_limit_ms': 1000,
+                'cost_limit_microunits': 1,
+            },
+        }
+    )
+
+    report = evaluate_benchmark(result, fixture, metadata)
+
+    assert report['passed'] is False
+    assert report['failures'] == [
+        'availability-mismatch',
+        'configuration-mismatch',
+        'cost-budget-exceeded',
+        'dns-outcome-mismatch',
+        'dns-query-accounting-mismatch',
+        'dns-query-budget-exceeded',
+        'fixture-source-mismatch',
+        'known-false-primary',
+        'missing-dns-evidence',
+        'missing-selected-activity',
+        'out-of-scope-promotion',
+        'partial-run',
+        'request-budget-exceeded',
+        'runtime-budget-exceeded',
+        'unselected-activity',
+        'wildcard-false-positive',
+    ]
+    assert report['metrics']['wildcard_false_positive_count'] == 1
+    assert report['metrics']['out_of_scope_promotion_count'] == 1
+    assert report['metrics']['source_failures']['failed'] == 1
+
+
+def _sanitized_case(arm_id: str, qps: int = 10) -> tuple[RunResult, BenchmarkFixture, BenchmarkRunMetadata]:
+    observation = _observation('private-name.benchmark.test', 'provider-secret-token', 'sensitive-family')
+    raw_payload_marker = _observation(
+        'raw-provider-payload-marker',
+        'provider-secret-token',
+        'sensitive-family',
+        ScopeClass.SCOPE_EXTENSION,
+    )
+    validation = _validation(observation.value)
+    started = datetime(2026, 1, 1, tzinfo=UTC)
+    result = RunResult(
+        run_id='private-run-id',
+        target='benchmark.test',
+        started_at=started,
+        completed_at=started + timedelta(milliseconds=100),
+        source_executions=(_execution('provider-secret-token', 'sensitive-family'),),
+        observations=(observation, raw_payload_marker),
+        dns_validations=(validation,),
+        entities=(MergedEntity(observation.value, (observation,), Addressability.CURRENT, (validation,)),),
+    )
+    fixture = BenchmarkFixture.from_dict(
+        {
+            'fixture_id': 'sanitized-v1',
+            'expected_in_scope': [observation.value],
+            'dns_outcomes': {observation.value: 'currently-addressable'},
+            'wildcard_ancestry': {},
+            'scope_extensions': ['scope-extension.private.test'],
+            'external_relationships': ['external.private.test'],
+            'source_payloads': {
+                'provider-secret-token': [observation.value, raw_payload_marker.value],
+            },
+            'primary_truth': [observation.value],
+            'known_inventory': [observation.value],
+            'known_false': ['known-false.private.test'],
+        }
+    )
+    settings = {'qps_limit': qps}
+    metadata = BenchmarkRunMetadata.from_dict(
+        {
+            'arm_id': arm_id,
+            'selected_sources': ['provider-secret-token'],
+            'selected_actions': ['dns-validation'],
+            'provider_availability': {'provider-secret-token': True},
+            'request_count': 1,
+            'dns_query_count': 1,
+            'declared_cost_microunits': 0,
+            'declared_settings': settings,
+            'effective_settings': settings,
+            'budget': {
+                'request_limit': 5,
+                'dns_query_limit': 1,
+                'runtime_limit_ms': 500,
+                'cost_limit_microunits': 0,
+            },
+        }
+    )
+    return result, fixture, metadata
+
+
+def test_selected_source_must_match_the_complete_deterministic_fixture_payload() -> None:
+    result, fixture, metadata = _sanitized_case('missing-payload')
+    fixture = replace(
+        fixture,
+        source_payloads={
+            'provider-secret-token': (*fixture.source_payloads['provider-secret-token'], 'missing.benchmark.test'),
+        },
+    )
+
+    report = evaluate_benchmark(result, fixture, metadata)
+
+    assert report['failures'] == ['fixture-source-mismatch']
+
+
+def test_benchmark_artifact_is_deterministic_and_contains_only_aggregate_labels() -> None:
+    result, fixture, metadata = _sanitized_case('baseline')
+    report = evaluate_benchmark(result, fixture, metadata)
+
+    artifact = serialize_benchmark(report)
+
+    assert artifact == serialize_benchmark(report)
+    assert json.loads(artifact)['attribution']['sources'][0]['source'].startswith('source-')
+    for forbidden in (
+        'benchmark.test',
+        'private-name',
+        'provider-secret-token',
+        'sensitive-family',
+        'raw-provider-payload-marker',
+        'private-run-id',
+        'scope-extension.private.test',
+        'external.private.test',
+        'known-false.private.test',
+        '2026-01-01',
+    ):
+        assert forbidden not in artifact
+
+
+def test_comparison_requires_equal_budgets_and_provider_availability_but_allows_tunable_settings() -> None:
+    result, fixture, baseline_metadata = _sanitized_case('baseline', qps=10)
+    _, _, candidate_metadata = _sanitized_case('candidate', qps=20)
+    baseline = evaluate_benchmark(result, fixture, baseline_metadata)
+    candidate = evaluate_benchmark(result, fixture, candidate_metadata)
+
+    comparison = compare_benchmarks((baseline, candidate))
+
+    assert comparison == {
+        'schema_version': 'theharvester-benchmark-comparison-v1',
+        'comparable': True,
+        'reason': None,
+        'arms': [
+            {
+                'arm_id': 'baseline',
+                'effective_settings': {'qps_limit': 10},
+                'unique_currently_addressable_yield': 1,
+                'yield_delta_from_baseline': 0,
+            },
+            {
+                'arm_id': 'candidate',
+                'effective_settings': {'qps_limit': 20},
+                'unique_currently_addressable_yield': 1,
+                'yield_delta_from_baseline': 0,
+            },
+        ],
+    }
+
+    candidate['budget']['request_limit'] = 6
+    assert compare_benchmarks((baseline, candidate))['reason'] == 'unequal-budget'
+    candidate['budget']['request_limit'] = 5
+    candidate['fixture_id'] = 'different-fixture'
+    assert compare_benchmarks((baseline, candidate))['reason'] == 'unequal-fixture'
+    candidate['fixture_id'] = baseline['fixture_id']
+    candidate['comparison_context']['provider_availability'] = {'source-different': True}
+    assert compare_benchmarks((baseline, candidate))['reason'] == 'unequal-provider-availability'
+
+
+def test_public_cli_scores_local_jsonl_and_writes_only_the_sanitized_artifact(tmp_path: Path) -> None:
+    fixture_path = tmp_path / 'truth.fixture'
+    observation = _observation('api.benchmark.test', 'fixture-a', 'shared-corpus')
+    validation = _validation(observation.value)
+    started = datetime(2026, 1, 1, tzinfo=UTC)
+    result = RunResult(
+        run_id='local-private-run',
+        target='benchmark.test',
+        started_at=started,
+        completed_at=started + timedelta(milliseconds=50),
+        source_executions=(_execution('fixture-a', 'shared-corpus'),),
+        observations=(observation,),
+        dns_validations=(validation,),
+        entities=(MergedEntity(observation.value, (observation,), Addressability.CURRENT, (validation,)),),
+    )
+    metadata = {
+        'arm_id': 'cli-baseline',
+        'selected_sources': ['fixture-a'],
+        'selected_actions': ['dns-validation'],
+        'provider_availability': {'fixture-a': True},
+        'request_count': 1,
+        'dns_query_count': 1,
+        'declared_cost_microunits': 0,
+        'declared_settings': {'qps_limit': 10},
+        'effective_settings': {'qps_limit': 10},
+        'budget': {
+            'request_limit': 5,
+            'dns_query_limit': 1,
+            'runtime_limit_ms': 100,
+            'cost_limit_microunits': 0,
+        },
+    }
+    run_path = tmp_path / 'run.jsonl'
+    metadata_path = tmp_path / 'metadata.json'
+    output_path = tmp_path / 'report.json'
+    fixture_path.write_text(
+        json.dumps(
+            {
+                'fixture_id': 'cli-v1',
+                'expected_in_scope': [observation.value],
+                'dns_outcomes': {observation.value: 'currently-addressable'},
+                'wildcard_ancestry': {},
+                'scope_extensions': ['related.example.test'],
+                'external_relationships': ['cdn.vendor.test'],
+                'source_payloads': {'fixture-a': [observation.value]},
+                'primary_truth': [observation.value],
+                'known_inventory': [observation.value],
+                'known_false': ['wild.benchmark.test'],
+            }
+        ),
+        encoding='utf-8',
+    )
+    run_path.write_text(run_result_jsonl(result), encoding='utf-8')
+    metadata_path.write_text(json.dumps(metadata), encoding='utf-8')
+
+    exit_code = main(
+        [
+            '--run-jsonl',
+            str(run_path),
+            '--fixture',
+            str(fixture_path),
+            '--metadata',
+            str(metadata_path),
+            '--output',
+            str(output_path),
+        ]
+    )
+
+    artifact = output_path.read_text(encoding='utf-8')
+    assert exit_code == 0
+    assert json.loads(artifact)['metrics']['unique_currently_addressable_yield'] == 1
+    assert 'benchmark.test' not in artifact
+    assert 'local-private-run' not in artifact
+
+
+def test_public_cli_fails_closed_without_echoing_sensitive_input_details(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    secret_path = tmp_path / 'private-client-name-and-token.jsonl'
+    secret_path.write_text('raw-secret-payload', encoding='utf-8')
+
+    exit_code = main(
+        [
+            '--run-jsonl',
+            str(secret_path),
+            '--fixture',
+            str(secret_path),
+            '--metadata',
+            str(secret_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert captured.out == ''
+    assert captured.err == 'benchmark input error\n'
+
+
+class FixtureSource:
+    def __init__(self, name: str, family: str, values: tuple[str, ...], fixture: BenchmarkFixture) -> None:
+        self.name = name
+        self.family = family
+        self.values = values
+        self.fixture = fixture
+
+    async def collect(self, _target: str) -> tuple[SourceFinding, ...]:
+        return tuple(
+            SourceFinding(
+                value,
+                Derivation.EXTERNAL_RELATIONSHIP
+                if value in self.fixture.external_relationships
+                else Derivation.RELATED
+                if value in self.fixture.scope_extensions
+                else Derivation.PROVIDER,
+            )
+            for value in self.values
+        )
+
+
+class FixtureResolver:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    async def query(self, hostname: str) -> DNSResponse:
+        if hostname.startswith('th-'):
+            if hostname.endswith('.dev.benchmark.test'):
+                return DNSResponse(ipv4=('192.0.2.200',))
+            return DNSResponse(rcode='NXDOMAIN')
+        if hostname == 'api.benchmark.test':
+            return DNSResponse(ipv4=('192.0.2.10',))
+        if hostname == 'ipv6.benchmark.test':
+            return DNSResponse(ipv6=('2001:db8::10',))
+        if hostname == 'alias.benchmark.test':
+            return DNSResponse(ipv4=('192.0.2.11',), cnames=('origin.benchmark.test',))
+        if hostname == 'ghost.dev.benchmark.test':
+            return DNSResponse(ipv4=('192.0.2.200',))
+        if hostname == 'disputed.benchmark.test':
+            if self.name == 'resolver-a':
+                return DNSResponse(ipv4=('192.0.2.12',))
+            if self.name == 'resolver-b':
+                return DNSResponse(rcode='NXDOMAIN')
+            return DNSResponse(rcode='ERROR', error='synthetic resolver error')
+        if hostname == 'nodata.benchmark.test':
+            return DNSResponse(rcode='NODATA')
+        return DNSResponse(rcode='NXDOMAIN')
+
+
+@pytest.mark.asyncio
+async def test_repo_fixture_runs_only_through_fake_source_and_resolver_boundaries() -> None:
+    fixture_path = Path(__file__).parents[1] / 'fixtures' / 'benchmark' / 'truth.fixture'
+    fixture = BenchmarkFixture.from_dict(json.loads(fixture_path.read_text(encoding='utf-8')))
+    families = {
+        'fixture-a': 'shared-corpus',
+        'fixture-a-mirror': 'shared-corpus',
+        'fixture-b': 'independent-corpus',
+    }
+    resolvers = tuple(FixtureResolver(name) for name in ('resolver-a', 'resolver-b', 'resolver-c'))
+    result = None
+    for source_name, payload in fixture.source_payloads.items():
+        result = await execute_run(
+            'benchmark.test',
+            FixtureSource(source_name, families[source_name], payload, fixture),
+            resolver_vantages=resolvers,
+            persist=False,
+            base_result=result,
+        )
+    assert result is not None
+    settings = _numeric_settings()
+    metadata = BenchmarkRunMetadata.from_dict(
+        {
+            'arm_id': 'synthetic-fixture',
+            'selected_sources': list(fixture.source_payloads),
+            'selected_actions': ['dns-validation'],
+            'provider_availability': dict.fromkeys(fixture.source_payloads, True),
+            'request_count': len(fixture.source_payloads),
+            'dns_query_count': len(result.dns_validations),
+            'declared_cost_microunits': 0,
+            'declared_settings': settings,
+            'effective_settings': settings,
+            'budget': {
+                'request_limit': 10,
+                'dns_query_limit': 1000,
+                'runtime_limit_ms': 5000,
+                'cost_limit_microunits': 0,
+            },
+        }
+    )
+
+    report = evaluate_benchmark(result, fixture, metadata)
+
+    assert {
+        entity.value: entity.addressability.value
+        for entity in result.entities
+        if entity.value in fixture.dns_outcomes
+    } == fixture.dns_outcomes
+    assert report['failures'] == []
+    assert report['passed'] is True
+    assert report['metrics']['unique_currently_addressable_yield'] == 3
+    assert report['metrics']['resolver_disagreement_count'] == 1
+    assert report['metrics']['wildcard_false_positive_count'] == 0
+    assert report['attribution']['independent_family_counts'] == {'1': 2, '2': 1}

--- a/theHarvester/lib/benchmark.py
+++ b/theHarvester/lib/benchmark.py
@@ -1,0 +1,611 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from itertools import combinations
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from theHarvester.lib.run import (
+    Addressability,
+    Derivation,
+    DiscoveryObservation,
+    DNSValidationObservation,
+    MergedEntity,
+    RunResult,
+    RunStatus,
+    ScopeClass,
+    SourceExecution,
+    SourceStatus,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+Number = int | float
+_PUBLIC_ID_CHARS = frozenset('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-')
+
+
+def _public_id(value: object, field: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not 1 <= len(value) <= 64
+        or value[0] not in _PUBLIC_ID_CHARS
+        or any(character not in _PUBLIC_ID_CHARS for character in value)
+    ):
+        raise ValueError(f'{field} must be a 1-64 character public identifier')
+    return value
+
+
+def _strings(value: object, field: str) -> frozenset[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f'{field} must be a list of strings')
+    return frozenset(value)
+
+
+def _string_map(value: object, field: str) -> dict[str, str]:
+    if not isinstance(value, dict) or not all(isinstance(key, str) and isinstance(item, str) for key, item in value.items()):
+        raise ValueError(f'{field} must map strings to strings')
+    return dict(value)
+
+
+def _source_payloads(value: object) -> dict[str, tuple[str, ...]]:
+    if not isinstance(value, dict):
+        raise ValueError('source_payloads must be an object')
+    payloads: dict[str, tuple[str, ...]] = {}
+    for source, items in value.items():
+        if not isinstance(source, str) or not isinstance(items, list) or not all(isinstance(item, str) for item in items):
+            raise ValueError('source_payloads must map source names to lists of strings')
+        payloads[source] = tuple(items)
+    return payloads
+
+
+def _settings(value: object, field: str) -> dict[str, Number]:
+    if not isinstance(value, dict) or not all(
+        isinstance(key, str) and isinstance(item, (int, float)) and not isinstance(item, bool) for key, item in value.items()
+    ):
+        raise ValueError(f'{field} must map names to numeric values')
+    return {_public_id(key, f'{field} key'): item for key, item in value.items()}
+
+
+def _nonnegative_int(value: object, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f'{field} must be a non-negative integer')
+    return value
+
+
+def _nonnegative_number(value: object, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        raise ValueError(f'{field} must be a non-negative number')
+    return float(value)
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkFixture:
+    fixture_id: str
+    expected_in_scope: frozenset[str]
+    dns_outcomes: Mapping[str, str]
+    wildcard_ancestry: Mapping[str, str]
+    scope_extensions: frozenset[str]
+    external_relationships: frozenset[str]
+    source_payloads: Mapping[str, tuple[str, ...]]
+    primary_truth: frozenset[str]
+    known_inventory: frozenset[str]
+    known_false: frozenset[str]
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> BenchmarkFixture:
+        required = {
+            'fixture_id',
+            'expected_in_scope',
+            'dns_outcomes',
+            'wildcard_ancestry',
+            'scope_extensions',
+            'external_relationships',
+            'source_payloads',
+            'primary_truth',
+            'known_inventory',
+            'known_false',
+        }
+        missing = required - data.keys()
+        if missing:
+            raise ValueError(f'missing fixture fields: {", ".join(sorted(missing))}')
+        fixture = cls(
+            fixture_id=_public_id(data['fixture_id'], 'fixture_id'),
+            expected_in_scope=_strings(data['expected_in_scope'], 'expected_in_scope'),
+            dns_outcomes=_string_map(data['dns_outcomes'], 'dns_outcomes'),
+            wildcard_ancestry=_string_map(data['wildcard_ancestry'], 'wildcard_ancestry'),
+            scope_extensions=_strings(data['scope_extensions'], 'scope_extensions'),
+            external_relationships=_strings(data['external_relationships'], 'external_relationships'),
+            source_payloads=_source_payloads(data['source_payloads']),
+            primary_truth=_strings(data['primary_truth'], 'primary_truth'),
+            known_inventory=_strings(data['known_inventory'], 'known_inventory'),
+            known_false=_strings(data['known_false'], 'known_false'),
+        )
+        if not fixture.primary_truth <= fixture.expected_in_scope:
+            raise ValueError('primary_truth must be a subset of expected_in_scope')
+        if not fixture.known_inventory <= fixture.primary_truth:
+            raise ValueError('known_inventory must be a subset of primary_truth')
+        if fixture.dns_outcomes.keys() != fixture.expected_in_scope:
+            raise ValueError('dns_outcomes must cover expected_in_scope exactly')
+        if any(outcome not in Addressability for outcome in fixture.dns_outcomes.values()):
+            raise ValueError('dns_outcomes contains an unsupported addressability')
+        if not fixture.wildcard_ancestry.keys() <= fixture.expected_in_scope:
+            raise ValueError('wildcard_ancestry names must be expected in-scope names')
+        return fixture
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkBudget:
+    request_limit: int
+    dns_query_limit: int
+    runtime_limit_ms: float
+    cost_limit_microunits: int
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> BenchmarkBudget:
+        return cls(
+            request_limit=_nonnegative_int(data.get('request_limit'), 'request_limit'),
+            dns_query_limit=_nonnegative_int(data.get('dns_query_limit'), 'dns_query_limit'),
+            runtime_limit_ms=_nonnegative_number(data.get('runtime_limit_ms'), 'runtime_limit_ms'),
+            cost_limit_microunits=_nonnegative_int(data.get('cost_limit_microunits'), 'cost_limit_microunits'),
+        )
+
+    def to_dict(self) -> dict[str, int | float]:
+        return {
+            'request_limit': self.request_limit,
+            'dns_query_limit': self.dns_query_limit,
+            'runtime_limit_ms': self.runtime_limit_ms,
+            'cost_limit_microunits': self.cost_limit_microunits,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkRunMetadata:
+    arm_id: str
+    selected_sources: frozenset[str]
+    selected_actions: frozenset[str]
+    provider_availability: Mapping[str, bool]
+    request_count: int
+    dns_query_count: int
+    declared_cost_microunits: int
+    declared_settings: Mapping[str, Number]
+    effective_settings: Mapping[str, Number]
+    budget: BenchmarkBudget
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> BenchmarkRunMetadata:
+        availability = data.get('provider_availability')
+        budget = data.get('budget')
+        if not isinstance(availability, dict) or not all(
+            isinstance(source, str) and isinstance(available, bool) for source, available in availability.items()
+        ):
+            raise ValueError('provider_availability must map source names to booleans')
+        if not isinstance(budget, dict):
+            raise ValueError('budget must be an object')
+        return cls(
+            arm_id=_public_id(data.get('arm_id'), 'arm_id'),
+            selected_sources=_strings(data.get('selected_sources'), 'selected_sources'),
+            selected_actions=_strings(data.get('selected_actions'), 'selected_actions'),
+            provider_availability=dict(availability),
+            request_count=_nonnegative_int(data.get('request_count'), 'request_count'),
+            dns_query_count=_nonnegative_int(data.get('dns_query_count'), 'dns_query_count'),
+            declared_cost_microunits=_nonnegative_int(data.get('declared_cost_microunits'), 'declared_cost_microunits'),
+            declared_settings=_settings(data.get('declared_settings'), 'declared_settings'),
+            effective_settings=_settings(data.get('effective_settings'), 'effective_settings'),
+            budget=BenchmarkBudget.from_dict(budget),
+        )
+
+
+def _ratio(numerator: int, denominator: int) -> dict[str, int | str | None]:
+    return {
+        'numerator': numerator,
+        'denominator': denominator,
+        'ratio': f'{numerator / denominator:.6f}' if denominator else None,
+    }
+
+
+def _labels(values: set[str], prefix: str) -> dict[str, str]:
+    return {value: f'{prefix}-{hashlib.sha256(value.encode()).hexdigest()[:12]}' for value in sorted(values)}
+
+
+def _source_attribution(result: RunResult, primary: set[str]) -> dict[str, object]:
+    primary_entities = tuple(entity for entity in result.entities if entity.value in primary)
+    sources = {observation.source for entity in primary_entities for observation in entity.observations} | {
+        execution.source for execution in result.source_executions
+    }
+    families = {observation.source_family for entity in primary_entities for observation in entity.observations} | {
+        execution.source_family for execution in result.source_executions
+    }
+    source_labels = _labels(sources, 'source')
+    family_labels = _labels(families, 'family')
+    source_family = {execution.source: execution.source_family for execution in result.source_executions}
+    for entity in primary_entities:
+        for observation in entity.observations:
+            source_family[observation.source] = observation.source_family
+
+    source_results = []
+    for source in sorted(sources):
+        supported = {
+            entity.value for entity in primary_entities if source in {observation.source for observation in entity.observations}
+        }
+        exclusive = {
+            entity.value for entity in primary_entities if {observation.source for observation in entity.observations} == {source}
+        }
+        source_results.append(
+            {
+                'source': source_labels[source],
+                'source_family': family_labels[source_family[source]],
+                'currently_addressable_yield': len(supported),
+                'source_alone_yield': len(supported),
+                'exclusive_yield': len(exclusive),
+            }
+        )
+
+    family_results = []
+    corroboration: dict[str, int] = {}
+    family_overlap_counts: dict[tuple[str, str], int] = {}
+    for family in sorted(families):
+        supported = {
+            entity.value
+            for entity in primary_entities
+            if family in {observation.source_family for observation in entity.observations}
+        }
+        family_results.append({'source_family': family_labels[family], 'currently_addressable_yield': len(supported)})
+    for entity in primary_entities:
+        entity_families = sorted({observation.source_family for observation in entity.observations})
+        count = len(entity_families)
+        corroboration[str(count)] = corroboration.get(str(count), 0) + 1
+        for left, right in combinations(entity_families, 2):
+            pair = (family_labels[left], family_labels[right])
+            family_overlap_counts[pair] = family_overlap_counts.get(pair, 0) + 1
+
+    return {
+        'combined_unique_yield': len(primary),
+        'sources': source_results,
+        'source_families': family_results,
+        'independent_family_counts': dict(sorted(corroboration.items())),
+        'family_overlaps': [
+            {'source_families': list(pair), 'yield': count} for pair, count in sorted(family_overlap_counts.items())
+        ],
+    }
+
+
+def evaluate_benchmark(
+    result: RunResult,
+    fixture: BenchmarkFixture,
+    metadata: BenchmarkRunMetadata,
+) -> dict[str, Any]:
+    """Evaluate one completed run without exposing entity-level evidence."""
+
+    def is_subdomain(value: str) -> bool:
+        return value.endswith(f'.{result.target}')
+
+    primary = {
+        entity.value
+        for entity in result.entities
+        if entity.addressability is Addressability.CURRENT
+        and ScopeClass.IN_SCOPE in entity.scope_classes
+        and is_subdomain(entity.value)
+    }
+    true_primary = primary & fixture.primary_truth
+    wildcard_false = primary & (fixture.known_false | fixture.wildcard_ancestry.keys())
+    out_of_scope_current = {
+        entity.value
+        for entity in result.entities
+        if entity.addressability is Addressability.CURRENT
+        and (
+            not is_subdomain(entity.value)
+            or ScopeClass.IN_SCOPE not in entity.scope_classes
+            or entity.value in fixture.scope_extensions
+            or entity.value in fixture.external_relationships
+        )
+    }
+    missing_dns_evidence = {
+        entity.value
+        for entity in result.entities
+        if entity.addressability is Addressability.CURRENT
+        and not any(
+            not validation.is_wildcard_control and bool(validation.ipv4 or validation.ipv6)
+            for validation in entity.dns_validations
+        )
+    }
+    dns_outcome_mismatches = {
+        entity.value
+        for entity in result.entities
+        if (expected := fixture.dns_outcomes.get(entity.value)) is not None and entity.addressability.value != expected
+    }
+    observed_source_payloads = {
+        source: {
+            observation.value
+            for observation in result.observations
+            if observation.source == source and not observation.source.startswith('action:')
+        }
+        for source in metadata.selected_sources
+    }
+    fixture_source_mismatch = any(
+        observed_source_payloads[source] != set(fixture.source_payloads.get(source, ())) for source in metadata.selected_sources
+    )
+    actual_executions = {execution.source for execution in result.source_executions}
+    expected_executions = metadata.selected_sources | {
+        f'action:{action}' for action in metadata.selected_actions if action != 'dns-validation'
+    }
+    incomplete_statuses = {SourceStatus.FAILED, SourceStatus.RATE_LIMITED, SourceStatus.SKIPPED}
+    failure_counts = {
+        status.value: sum(execution.status is status for execution in result.source_executions)
+        for status in sorted(incomplete_statuses, key=str)
+    }
+    runtime_ms = max(0.0, (result.completed_at - result.started_at).total_seconds() * 1000)
+    availability_labels = _labels(set(metadata.provider_availability), 'source')
+
+    failures: list[str] = []
+    if primary - fixture.primary_truth:
+        failures.append('known-false-primary')
+    if wildcard_false:
+        failures.append('wildcard-false-positive')
+    if missing_dns_evidence:
+        failures.append('missing-dns-evidence')
+    if dns_outcome_mismatches:
+        failures.append('dns-outcome-mismatch')
+    if fixture_source_mismatch:
+        failures.append('fixture-source-mismatch')
+    if out_of_scope_current or any(
+        observation.derivation is Derivation.RECURSIVE_DNS
+        and (
+            observation.value not in fixture.expected_in_scope
+            or (observation.parent is not None and observation.parent not in fixture.expected_in_scope | {result.target})
+        )
+        for observation in result.observations
+    ):
+        failures.append('out-of-scope-promotion')
+    if (
+        actual_executions - expected_executions
+        or any(observation.source not in expected_executions for observation in result.observations)
+        or (bool(result.dns_validations) and 'dns-validation' not in metadata.selected_actions)
+    ):
+        failures.append('unselected-activity')
+    if expected_executions - actual_executions or ('dns-validation' in metadata.selected_actions and not result.dns_validations):
+        failures.append('missing-selected-activity')
+    if result.status is not RunStatus.COMPLETE or any(failure_counts.values()) or not result.source_executions:
+        failures.append('partial-run')
+    if metadata.declared_settings != metadata.effective_settings:
+        failures.append('configuration-mismatch')
+    if any(not metadata.provider_availability.get(source, False) for source in metadata.selected_sources):
+        failures.append('availability-mismatch')
+    if metadata.request_count > metadata.budget.request_limit:
+        failures.append('request-budget-exceeded')
+    if metadata.dns_query_count > metadata.budget.dns_query_limit:
+        failures.append('dns-query-budget-exceeded')
+    if metadata.dns_query_count != len(result.dns_validations):
+        failures.append('dns-query-accounting-mismatch')
+    if runtime_ms > metadata.budget.runtime_limit_ms:
+        failures.append('runtime-budget-exceeded')
+    if metadata.declared_cost_microunits > metadata.budget.cost_limit_microunits:
+        failures.append('cost-budget-exceeded')
+
+    return {
+        'schema_version': 'theharvester-benchmark-v1',
+        'fixture_id': fixture.fixture_id,
+        'arm_id': metadata.arm_id,
+        'passed': not failures,
+        'failures': sorted(set(failures)),
+        'metrics': {
+            'unique_currently_addressable_yield': len(primary),
+            'known_inventory_recovery': _ratio(len(primary & fixture.known_inventory), len(fixture.known_inventory)),
+            'precision': _ratio(len(true_primary), len(primary)),
+            'wildcard_false_positive_count': len(wildcard_false),
+            'resolver_disagreement_count': sum(
+                entity.addressability is Addressability.RESOLVER_DISPUTED for entity in result.entities
+            ),
+            'out_of_scope_promotion_count': len(out_of_scope_current),
+            'source_failures': failure_counts,
+            'runtime_ms': round(runtime_ms, 6),
+            'request_count': metadata.request_count,
+            'dns_query_count': metadata.dns_query_count,
+            'declared_cost_microunits': metadata.declared_cost_microunits,
+        },
+        'attribution': _source_attribution(result, primary),
+        'effective_settings': dict(sorted(metadata.effective_settings.items())),
+        'budget': metadata.budget.to_dict(),
+        'comparison_context': {
+            'provider_availability': {
+                availability_labels[source]: metadata.provider_availability[source]
+                for source in sorted(metadata.provider_availability)
+            },
+        },
+    }
+
+
+def serialize_benchmark(report: Mapping[str, object]) -> str:
+    """Return a canonical aggregate-only benchmark artifact."""
+    return json.dumps(report, sort_keys=True, separators=(',', ':'))
+
+
+def compare_benchmarks(reports: tuple[Mapping[str, Any], ...]) -> dict[str, object]:
+    """Compare qualified arms only under the same declared budget and provider availability."""
+    if len(reports) < 2:
+        raise ValueError('at least two benchmark reports are required')
+    baseline_context = reports[0].get('comparison_context')
+    if not isinstance(baseline_context, dict):
+        raise ValueError('benchmark report is missing comparison context')
+    contexts = [report.get('comparison_context') for report in reports]
+    reason: str | None = None
+    if any(not report.get('passed') for report in reports):
+        reason = 'qualification-failed'
+    elif any(not isinstance(context, dict) for context in contexts):
+        reason = 'missing-comparison-context'
+    elif any(report.get('fixture_id') != reports[0].get('fixture_id') for report in reports[1:]):
+        reason = 'unequal-fixture'
+    elif any(report.get('budget') != reports[0].get('budget') for report in reports[1:]):
+        reason = 'unequal-budget'
+    elif any(
+        isinstance(context, dict) and context.get('provider_availability') != baseline_context.get('provider_availability')
+        for context in contexts[1:]
+    ):
+        reason = 'unequal-provider-availability'
+
+    arms: list[dict[str, object]] = []
+    if reason is None:
+        baseline_metrics = reports[0].get('metrics')
+        if not isinstance(baseline_metrics, dict):
+            raise ValueError('benchmark report is missing metrics')
+        baseline_yield = baseline_metrics.get('unique_currently_addressable_yield')
+        if not isinstance(baseline_yield, int):
+            raise ValueError('benchmark yield must be an integer')
+        for report in reports:
+            metrics = report.get('metrics')
+            settings = report.get('effective_settings')
+            arm_id = report.get('arm_id')
+            if not isinstance(metrics, dict) or not isinstance(settings, dict) or not isinstance(arm_id, str):
+                raise ValueError('benchmark report is missing arm data')
+            current_yield = metrics.get('unique_currently_addressable_yield')
+            if not isinstance(current_yield, int):
+                raise ValueError('benchmark yield must be an integer')
+            arms.append(
+                {
+                    'arm_id': arm_id,
+                    'effective_settings': settings,
+                    'unique_currently_addressable_yield': current_yield,
+                    'yield_delta_from_baseline': current_yield - baseline_yield,
+                }
+            )
+
+    return {
+        'schema_version': 'theharvester-benchmark-comparison-v1',
+        'comparable': reason is None,
+        'reason': reason,
+        'arms': arms,
+    }
+
+
+def _discovery_observation(data: Mapping[str, Any]) -> DiscoveryObservation:
+    provider_observed_at = data.get('provider_observed_at')
+    return DiscoveryObservation(
+        run_id=data['run_id'],
+        target=data['target'],
+        value=data['value'],
+        source=data['source'],
+        source_family=data['source_family'],
+        derivation=Derivation(data['derivation']),
+        collected_at=datetime.fromisoformat(data['collected_at']),
+        scope_class=ScopeClass(data['scope_class']),
+        provider_observed_at=datetime.fromisoformat(provider_observed_at) if provider_observed_at is not None else None,
+        parent=data.get('parent'),
+    )
+
+
+def _dns_validation(data: Mapping[str, Any]) -> DNSValidationObservation:
+    return DNSValidationObservation(
+        run_id=data['run_id'],
+        candidate=data['candidate'],
+        query_name=data['query_name'],
+        resolver=data['resolver'],
+        queried_at=datetime.fromisoformat(data['validated_at']),
+        ipv4=tuple(data['ipv4']),
+        ipv6=tuple(data['ipv6']),
+        cnames=tuple(data['cnames']),
+        rcode=data['rcode'],
+        ttl=data['ttl'],
+        cname_chain=tuple(data['cname_chain']),
+        latency_ms=data['latency_ms'],
+        error=data['error'],
+        is_wildcard_control=data['is_wildcard_control'],
+        wildcard_depth=data['wildcard_depth'],
+    )
+
+
+def _source_execution(data: Mapping[str, Any]) -> SourceExecution:
+    return SourceExecution(
+        run_id=data['run_id'],
+        source=data['source'],
+        source_family=data['source_family'],
+        status=SourceStatus(data['status']),
+        duration_ms=data['duration_ms'],
+        result_count=data['result_count'],
+        observation_count=data['observation_count'],
+        entity_count=data['entity_count'],
+        error_type=data.get('error_type'),
+        query_count=data.get('query_count'),
+        depth_reached=data.get('depth_reached'),
+        zero_yield_batches=data.get('zero_yield_batches'),
+        stop_reason=data.get('stop_reason'),
+    )
+
+
+def load_run_jsonl(path: str | Path) -> RunResult:
+    """Load the existing normalized evidence JSONL for offline scoring."""
+    records: dict[str, list[dict[str, Any]]] = {}
+    for line_number, line in enumerate(Path(path).read_text(encoding='utf-8').splitlines(), 1):
+        if not line.strip():
+            continue
+        record = json.loads(line)
+        if not isinstance(record, dict) or record.get('schema_version') != 'theharvester-evidence-v1':
+            raise ValueError(f'invalid evidence record on line {line_number}')
+        record_type = record.get('record_type')
+        data = record.get('data')
+        if not isinstance(record_type, str) or not isinstance(data, dict):
+            raise ValueError(f'invalid evidence record on line {line_number}')
+        records.setdefault(record_type, []).append(data)
+    run_records = records.get('run', [])
+    if len(run_records) != 1:
+        raise ValueError('evidence JSONL must contain exactly one run record')
+    run = run_records[0]
+    observations = tuple(_discovery_observation(data) for data in records.get('discovery_observation', []))
+    validations = tuple(_dns_validation(data) for data in records.get('dns_validation_observation', []))
+    entities = tuple(
+        MergedEntity(
+            value=data['value'],
+            observations=tuple(_discovery_observation(item) for item in data['provenance']),
+            addressability=Addressability(data['addressability']),
+            dns_validations=tuple(validation for validation in validations if validation.candidate == data['value']),
+        )
+        for data in records.get('merged_result', [])
+    )
+    return RunResult(
+        run_id=run['run_id'],
+        target=run['target'],
+        started_at=datetime.fromisoformat(run['started_at']),
+        completed_at=datetime.fromisoformat(run['completed_at']),
+        source_executions=tuple(_source_execution(data) for data in records.get('source_execution', [])),
+        observations=observations,
+        dns_validations=validations,
+        entities=entities,
+    )
+
+
+def _load_json_object(path: str | Path) -> dict[str, object]:
+    data = json.loads(Path(path).read_text(encoding='utf-8'))
+    if not isinstance(data, dict):
+        raise ValueError(f'{path} must contain one JSON object')
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description='Score a completed evidence run against a deterministic fixture.')
+    parser.add_argument('--run-jsonl', required=True, help='Completed theHarvester evidence JSONL')
+    parser.add_argument('--fixture', required=True, help='Synthetic benchmark truth JSON')
+    parser.add_argument('--metadata', required=True, help='Applied settings, accounting, availability, and budget JSON')
+    parser.add_argument('--output', help='Write the sanitized report here instead of standard output')
+    args = parser.parse_args(argv)
+    try:
+        result = load_run_jsonl(args.run_jsonl)
+        fixture = BenchmarkFixture.from_dict(_load_json_object(args.fixture))
+        metadata = BenchmarkRunMetadata.from_dict(_load_json_object(args.metadata))
+        report = evaluate_benchmark(result, fixture, metadata)
+        artifact = serialize_benchmark(report)
+        if args.output:
+            Path(args.output).write_text(f'{artifact}\n', encoding='utf-8')
+        else:
+            print(artifact)
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
+        print('benchmark input error', file=sys.stderr)
+        return 2
+    return 0 if report['passed'] else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a deterministic offline discovery-quality benchmark
- compare candidates and verified results against a fixture truth set
- expose a benchmark CLI and document its use

## Stack

Depends on `codex/recursive-dns` because the benchmark measures the completed evidence and recursive-discovery model.

## Validation

`uv run pytest tests/lib/test_benchmark.py`

Result: 8 passed.
