### PR TITLE
Migrate Venacus to shared transport

### DIFF
--- a/tests/discovery/test_venacussearch.py
+++ b/tests/discovery/test_venacussearch.py
@@ -1,0 +1,70 @@
+from typing import Any
+
+import aiohttp
+import pytest
+
+from theHarvester.discovery import venacussearch
+
+
+@pytest.mark.asyncio
+async def test_process_preserves_paginated_results_through_shared_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[dict[str, Any]] = []
+
+    async def fail_direct_session(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError('Venacus must not create a direct aiohttp session')
+
+    async def fetch(**kwargs: Any) -> dict[str, Any]:
+        requests.append(kwargs)
+        if kwargs['params']['offset_doc'] == 0:
+            return {
+                'data': [{'tokens': [{'type': 'email', 'value': 'first@example.com'}]}],
+                'offset_doc': 1,
+                'offset_in_doc': 25,
+                'more': True,
+            }
+        return {
+            'data': [{'tokens': [{'type': 'email', 'value': 'second@example.com'}]}],
+            'offset_doc': 2,
+            'offset_in_doc': 0,
+            'more': False,
+        }
+
+    monkeypatch.setattr(aiohttp, 'ClientSession', fail_direct_session)
+    monkeypatch.setattr(venacussearch.Core, 'venacus_key', staticmethod(lambda: 'test-key'))
+    monkeypatch.setattr(venacussearch.Core, 'get_user_agent', staticmethod(lambda: 'test-agent'))
+    monkeypatch.setattr(venacussearch.AsyncFetcher, 'fetch', fetch)
+
+    search = venacussearch.SearchVenacus('example.com')
+    await search.process()
+
+    assert await search.get_emails() == {'first@example.com', 'second@example.com'}
+    assert requests == [
+        {
+            'url': 'https://api.venacus.com/v1/search/',
+            'headers': {'Authorization': 'Bearer test-key', 'User-Agent': 'test-agent-theHarvester'},
+            'params': {
+                'q': 'example.com',
+                'offset_doc': 0,
+                'offset_in_doc': 0,
+                'limit': 100,
+                'ai': 'false',
+            },
+            'json': True,
+            'response_delay': 0,
+            'use_system_ssl': True,
+        },
+        {
+            'url': 'https://api.venacus.com/v1/search/',
+            'headers': {'Authorization': 'Bearer test-key', 'User-Agent': 'test-agent-theHarvester'},
+            'params': {
+                'q': 'example.com',
+                'offset_doc': 1,
+                'offset_in_doc': 25,
+                'limit': 100,
+                'ai': 'false',
+            },
+            'json': True,
+            'response_delay': 0,
+            'use_system_ssl': True,
+        },
+    ]

--- a/theHarvester/discovery/venacussearch.py
+++ b/theHarvester/discovery/venacussearch.py
@@ -1,9 +1,7 @@
 from typing import Any
 
-import aiohttp
-
 from theHarvester.discovery.constants import MissingKey
-from theHarvester.lib.core import Core
+from theHarvester.lib.core import AsyncFetcher, Core
 from theHarvester.parsers import venacusparser
 
 
@@ -33,35 +31,40 @@ class SearchVenacus:
                 'User-Agent': f'{Core.get_user_agent()}-theHarvester',
             }
 
-            async with aiohttp.ClientSession() as session:
-                while self.more and result_count < self.limit:
-                    query = {
-                        'q': self.word,
-                        'offset_doc': self.offset_doc,
-                        'offset_in_doc': self.offset_in_doc,
-                        'limit': 100,
-                        'ai': 'true' if self.ai else 'false',
-                    }
+            while self.more and result_count < self.limit:
+                query = {
+                    'q': self.word,
+                    'offset_doc': self.offset_doc,
+                    'offset_in_doc': self.offset_in_doc,
+                    'limit': 100,
+                    'ai': 'true' if self.ai else 'false',
+                }
 
-                    async with session.get(f'{self.base_url}/v1/search/', headers=headers, params=query) as total_resp:
-                        search_data = await total_resp.json()
-                        current_results = search_data.get('data', [])
+                search_data = await AsyncFetcher.fetch(
+                    url=f'{self.base_url}/v1/search/',
+                    headers=headers,
+                    params=query,
+                    json=True,
+                    response_delay=0,
+                    use_system_ssl=True,
+                )
+                current_results = search_data.get('data', [])
 
-                        if not current_results:
-                            print('No more results found.')
-                            break
+                if not current_results:
+                    print('No more results found.')
+                    break
 
-                        total_results.extend(current_results)
-                        result_count += len(current_results)
+                total_results.extend(current_results)
+                result_count += len(current_results)
 
-                        self.offset_doc = search_data.get('offset_doc', 0)
-                        self.offset_in_doc = search_data.get('offset_in_doc', 0)
+                self.offset_doc = search_data.get('offset_doc', 0)
+                self.offset_in_doc = search_data.get('offset_in_doc', 0)
 
-                        self.more = search_data.get('more', False)
+                self.more = search_data.get('more', False)
 
-                self.results = total_results
-                if not self.results:
-                    print('No results found.')
+            self.results = total_results
+            if not self.results:
+                print('No results found.')
 
         except Exception as e:
             print(f'An exception has occurred in Venacus: {e}')


### PR DESCRIPTION
## Summary

- migrate Venacus to the shared transport
- preserve its request, response, and result behavior
- add focused adapter regression coverage

## Stack

Depends on `codex/transport-policy`.

The local `docs/agents/` audit update is intentionally excluded from this PR.

## Validation

`uv run pytest tests/discovery/test_venacussearch.py tests/lib/test_async_fetcher_contract.py`

Result: 21 passed.
