### PR TITLE
Add shared transport policy controls

### DIFF
--- a/tests/lib/test_async_fetcher_contract.py
+++ b/tests/lib/test_async_fetcher_contract.py
@@ -12,6 +12,7 @@ import aiohttp
 import pytest
 from aiohttp import web
 
+from theHarvester.lib import core as core_module
 from theHarvester.lib.core import AsyncFetcher
 
 if TYPE_CHECKING:
@@ -147,6 +148,65 @@ async def test_post_fetch_sends_body_formats(
 
 
 @pytest.mark.asyncio
+async def test_post_fetch_preserves_default_delay_and_allows_no_delay(
+    monkeypatch: pytest.MonkeyPatch,
+    unused_tcp_port: int,
+) -> None:
+    delays: list[int] = []
+
+    async def record_delay(delay: int) -> None:
+        delays.append(delay)
+
+    async def response(_request: web.Request) -> web.Response:
+        return web.Response(text='ok')
+
+    monkeypatch.setattr(core_module.asyncio, 'sleep', record_delay)
+    app = web.Application()
+    app.router.add_post('/', response)
+
+    async with running_app(app, unused_tcp_port) as base_url:
+        default_result = await AsyncFetcher.post_fetch(base_url)
+        no_delay_result = await AsyncFetcher.post_fetch(base_url, response_delay=0)
+        observed_delays = delays.copy()
+
+    assert (default_result, no_delay_result, observed_delays) == ('ok', 'ok', [3, 0])
+
+
+@pytest.mark.asyncio
+async def test_post_fetch_preserves_proxy_delay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    delays: list[int] = []
+
+    async def record_delay(delay: int) -> None:
+        delays.append(delay)
+
+    async def proxy_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            await reader.readuntil(b'\r\n\r\n')
+            writer.write(http_response('ok'))
+            await writer.drain()
+        finally:
+            await close_writer(writer)
+
+    monkeypatch.setattr(core_module.asyncio, 'sleep', record_delay)
+
+    async with running_raw_server(proxy_handler) as (host, port):
+        proxy_url = f'http://{host}:{port}'
+        monkeypatch.setattr(AsyncFetcher, '_get_random_proxy', staticmethod(lambda _proxies: (proxy_url, 'http')))
+        monkeypatch.setattr(AsyncFetcher, 'proxy_list', {'http': [proxy_url]})
+        default_result = await AsyncFetcher.post_fetch('http://example.test/', proxy=True)
+        no_delay_result = await AsyncFetcher.post_fetch(
+            'http://example.test/',
+            proxy=True,
+            response_delay=0,
+        )
+        observed_delays = delays.copy()
+
+    assert (default_result, no_delay_result, observed_delays) == ('ok', 'ok', [5, 0])
+
+
+@pytest.mark.asyncio
 async def test_fetch_decodes_text_and_json_responses(unused_tcp_port: int) -> None:
     async def text_response(_request: web.Request) -> web.Response:
         return web.Response(text='plain response')
@@ -163,6 +223,31 @@ async def test_fetch_decodes_text_and_json_responses(unused_tcp_port: int) -> No
         json_result = await AsyncFetcher.fetch(url=f'{base_url}/json', json=True)
 
     assert (text_result, json_result) == ('plain response', {'result': 'structured'})
+
+
+@pytest.mark.asyncio
+async def test_fetch_preserves_default_delay_and_allows_no_delay(
+    monkeypatch: pytest.MonkeyPatch,
+    unused_tcp_port: int,
+) -> None:
+    delays: list[int] = []
+
+    async def record_delay(delay: int) -> None:
+        delays.append(delay)
+
+    async def response(_request: web.Request) -> web.Response:
+        return web.Response(text='ok')
+
+    monkeypatch.setattr(core_module.asyncio, 'sleep', record_delay)
+    app = web.Application()
+    app.router.add_get('/', response)
+
+    async with running_app(app, unused_tcp_port) as base_url:
+        default_result = await AsyncFetcher.fetch(url=base_url)
+        no_delay_result = await AsyncFetcher.fetch(url=base_url, response_delay=0)
+        observed_delays = delays.copy()
+
+    assert (default_result, no_delay_result, observed_delays) == ('ok', 'ok', [5, 0])
 
 
 @pytest.mark.asyncio
@@ -279,6 +364,61 @@ async def test_fetch_applies_tls_verification_option(unused_tcp_port: int) -> No
         unverified_result = await AsyncFetcher.fetch(url=base_url, verify=False)
 
     assert (verified_result, unverified_result) == ('', 'secure response')
+
+
+@pytest.mark.asyncio
+async def test_fetch_allows_aiohttp_default_tls_trust(unused_tcp_port: int) -> None:
+    async def secure_response(_request: web.Request) -> web.Response:
+        return web.Response(text='secure response')
+
+    server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    server_context.load_cert_chain(
+        FIXTURES_DIR / 'localhost-cert.pem',
+        FIXTURES_DIR / 'localhost-key.pem',
+    )
+    aiohttp_default_context = ssl.create_default_context(cafile=FIXTURES_DIR / 'localhost-cert.pem')
+    app = web.Application()
+    app.router.add_get('/', secure_response)
+
+    async with running_app(app, unused_tcp_port, ssl_context=server_context) as base_url:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=aiohttp_default_context)) as session:
+            certifi_result = await AsyncFetcher.fetch(
+                session=session,
+                url=base_url,
+                response_delay=0,
+            )
+            aiohttp_default_result = await AsyncFetcher.fetch(
+                session=session,
+                url=base_url,
+                use_system_ssl=True,
+                response_delay=0,
+            )
+
+    assert (certifi_result, aiohttp_default_result) == ('', 'secure response')
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_conflicting_tls_controls(unused_tcp_port: int) -> None:
+    request_count = 0
+
+    async def response(_request: web.Request) -> web.Response:
+        nonlocal request_count
+        request_count += 1
+        return web.Response(text='unexpected')
+
+    app = web.Application()
+    app.router.add_get('/', response)
+
+    async with running_app(app, unused_tcp_port) as base_url:
+        with pytest.raises(ValueError, match='use_system_ssl cannot be combined with verify=False'):
+            await AsyncFetcher.fetch(
+                url=base_url,
+                verify=False,
+                use_system_ssl=True,
+                response_delay=0,
+            )
+
+    assert request_count == 0
 
 
 @pytest.mark.asyncio

--- a/theHarvester/lib/core.py
+++ b/theHarvester/lib/core.py
@@ -434,9 +434,11 @@ class AsyncFetcher:
         return headers or {'User-Agent': Core.get_user_agent()}
 
     @staticmethod
-    def _ssl_context(verify: bool | None = True) -> ssl.SSLContext | bool:
+    def _ssl_context(verify: bool | None = True, use_system_ssl: bool = False) -> ssl.SSLContext | bool:
         if verify is False:
             return False
+        if use_system_ssl:
+            return True
         return ssl.create_default_context(cafile=certifi.where())
 
     @staticmethod
@@ -478,6 +480,8 @@ class AsyncFetcher:
         request_timeout: int | None = None,
         data: str | dict[str, Any] | object = _NO_BODY,
         json_body: dict[str, Any] | None = None,
+        response_delay: int | None = None,
+        use_system_ssl: bool = False,
     ) -> _RequestPlan:
         has_body = data is not _NO_BODY
         proxy_url, proxy_type = cls._resolve_proxy(proxy)
@@ -493,15 +497,15 @@ class AsyncFetcher:
             )
             if not proxy and params != '':
                 request_kwargs['ssl'] = ssl_context
-            response_delay = 5 if proxy else 3
+            default_response_delay = 5 if proxy else 3
             planned_request_timeout = None
         else:
             client_timeout = cls._request_timeout(request_timeout)
-            ssl_context = cls._ssl_context(verify)
+            ssl_context = cls._ssl_context(verify, use_system_ssl)
             request_kwargs['ssl'] = ssl_context
             if follow_redirects is not None:
                 request_kwargs['allow_redirects'] = follow_redirects
-            response_delay = 5
+            default_response_delay = 5
             planned_request_timeout = request_timeout
 
         if params != '':
@@ -519,7 +523,7 @@ class AsyncFetcher:
             ssl_context=ssl_context,
             request_kwargs=request_kwargs,
             response_json=response_json,
-            response_delay=response_delay,
+            response_delay=default_response_delay if response_delay is None else response_delay,
             request_timeout=planned_request_timeout,
         )
 
@@ -625,6 +629,8 @@ class AsyncFetcher:
         json: bool = False,
         proxy: bool = False,
         json_body: dict[str, Any] | None = None,
+        *,
+        response_delay: int | None = None,
     ):
         # By default, timeout is 5 minutes, changed to 12-minutes
         # results are well worth the wait
@@ -638,6 +644,7 @@ class AsyncFetcher:
                 proxy=proxy,
                 data=data,
                 json_body=json_body,
+                response_delay=response_delay,
             )
             return await cls._execute_request(plan)
         except (aiohttp.ClientError, TimeoutError, OSError, ssl.SSLError, UnicodeDecodeError, ValueError):
@@ -656,12 +663,17 @@ class AsyncFetcher:
         verify: bool | None = None,
         follow_redirects: bool | None = None,
         request_timeout: int | None = None,
+        *,
+        response_delay: int | None = None,
+        use_system_ssl: bool = False,
     ) -> Any:
         """Generic HTTP request helper.
         - If a session is not provided, one will be created and closed automatically.
         - Supports optional headers, method selection, proxy, ssl verification, redirects and timeout.
         - Returns response text or json depending on `json` flag.
         """
+        if use_system_ssl and verify is False:
+            raise ValueError('use_system_ssl cannot be combined with verify=False')
         try:
             plan = cls._plan_request(
                 method,
@@ -673,6 +685,8 @@ class AsyncFetcher:
                 verify=verify,
                 follow_redirects=follow_redirects,
                 request_timeout=request_timeout,
+                response_delay=response_delay,
+                use_system_ssl=use_system_ssl,
             )
             return await cls._execute_request(plan, session)
         except (aiohttp.ClientError, TimeoutError, OSError, ssl.SSLError, UnicodeDecodeError, ValueError):


### PR DESCRIPTION
## Summary

- add explicit timeout, retry-delay, and TLS policy controls
- retain secure defaults
- cover policy behavior through the shared transport contract

## Stack

Depends on `codex/request-planning`.

## Validation

`uv run pytest tests/lib/test_async_fetcher_contract.py`

Result: 20 passed.

