### PR TITLE
fix: honor quiet mode for missing API keys

### DIFF
--- a/tests/test_quiet.py
+++ b/tests/test_quiet.py
@@ -1,0 +1,52 @@
+import argparse
+
+import pytest
+
+import theHarvester.__main__ as main_module
+from theHarvester.discovery.constants import MissingKey
+
+
+class FakeStashManager:
+    async def do_init(self) -> None:
+        return None
+
+
+@pytest.mark.parametrize(
+    ('provider_module', 'class_name', 'source'),
+    [
+        (main_module.bevigil, 'SearchBeVigil', 'bevigil'),
+        (main_module.bitbucket, 'SearchBitBucket', 'bitbucket'),
+        (main_module.builtwith, 'SearchBuiltWith', 'builtwith'),
+    ],
+)
+@pytest.mark.asyncio
+async def test_quiet_suppresses_missing_key_errors(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], provider_module, class_name: str, source: str
+) -> None:
+    def missing_key(*_args, **_kwargs):
+        raise MissingKey(source)
+
+    monkeypatch.setattr(main_module.stash, 'StashManager', FakeStashManager)
+    monkeypatch.setattr(provider_module, class_name, missing_key)
+
+    await main_module.start(
+        argparse.Namespace(
+            api_scan=False,
+            dns_brute=False,
+            dns_lookup=False,
+            dns_resolve='',
+            dns_server=None,
+            domain='example.com',
+            filename='',
+            limit=5,
+            proxies=False,
+            quiet=True,
+            shodan=False,
+            source=source,
+            start=0,
+            take_over=False,
+            wordlist='',
+        )
+    )
+
+    assert 'Missing API key' not in capsys.readouterr().out

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -460,7 +460,8 @@ async def start(rest_args: argparse.Namespace | None = None):
                             )
                         )
                     except Exception as e:
-                        show_default_error_message(engineitem, word, error=e)
+                        if not isinstance(e, MissingKey) or not args.quiet:
+                            show_default_error_message(engineitem, word, error=e)
 
                 elif engineitem == 'bitbucket':
                     try:
@@ -475,7 +476,8 @@ async def start(rest_args: argparse.Namespace | None = None):
                         )
                     except Exception as ex:
                         if isinstance(ex, MissingKey):
-                            print(MissingKey('Bitbucket'))
+                            if not args.quiet:
+                                print(MissingKey('Bitbucket'))
                         else:
                             show_default_error_message(engineitem, word, ex)
 
@@ -513,8 +515,9 @@ async def start(rest_args: argparse.Namespace | None = None):
                         stor_lst.append(store(builtwith_search, engineitem, store_host=True, store_interestingurls=True))
                     except Exception as e:
                         if isinstance(e, MissingKey):
-                            print(f"Failed to perform BuiltWith search for word: '{word}'")
-                            print(f'A Missing Key Error occurred in builtwith: {e}')
+                            if not args.quiet:
+                                print(f"Failed to perform BuiltWith search for word: '{word}'")
+                                print(f'A Missing Key Error occurred in builtwith: {e}')
                         else:
                             show_default_error_message(engineitem, word, e)
 


### PR DESCRIPTION
## Summary

- honor `--quiet` for Bevigil, Bitbucket, and BuiltWith missing-key errors
- keep unrelated provider errors visible
- cover the three reproduced regressions through the CLI boundary

## Validation

`pytest tests/test_quiet.py`

Result: 3 passed.

The offline suite passes with the two existing live-network tests deselected: 117 passed, 4 skipped, 2 deselected.
