### PR TITLE
Fix source result aggregation contracts

### DIFF
--- a/tests/discovery/test_builtwith.py
+++ b/tests/discovery/test_builtwith.py
@@ -79,7 +79,7 @@ async def test_process_accepts_text_json_content_type(monkeypatch) -> None:
     await search.process()
 
     assert await search.get_hostnames() == {'sub.example.com'}
-    assert await search.get_interesting_urls() == {'https://example.com/login'}
+    assert await search.get_interestingurls() == {'https://example.com/login'}
     assert await search.get_frameworks() == {'Django'}
     assert await search.get_languages() == {'Python'}
     assert await search.get_servers() == {'nginx'}

--- a/tests/discovery/test_intelx.py
+++ b/tests/discovery/test_intelx.py
@@ -1,0 +1,12 @@
+import pytest
+
+from theHarvester.discovery import intelxsearch
+
+
+@pytest.mark.asyncio
+async def test_interesting_urls_match_the_shared_result_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(intelxsearch.Core, 'intelx_key', lambda: 'test-key')
+    search = intelxsearch.SearchIntelx('example.com')
+    search.info = ([], ['https://api.example.com/path'], [])
+
+    assert await search.get_interestingurls() == ['https://api.example.com/path']

--- a/tests/discovery/test_source_result_contracts.py
+++ b/tests/discovery/test_source_result_contracts.py
@@ -1,0 +1,103 @@
+import sys
+
+import pytest
+
+
+class DummyStashManager:
+    async def do_init(self) -> None:
+        return None
+
+    async def store_all(self, _domain: str, _results: object, _result_type: str, _source: str) -> None:
+        return None
+
+
+class DummyNetlas:
+    process_calls = 0
+
+    def __init__(self, _domain: str, _limit: int) -> None:
+        pass
+
+    async def process(self, _proxy: bool = False) -> None:
+        type(self).process_calls += 1
+
+    async def get_hostnames(self) -> set[str]:
+        return {'api.example.com'}
+
+
+class DummySecurityScorecard:
+    process_calls = 0
+
+    def __init__(self, _domain: str) -> None:
+        pass
+
+    async def process(self, _proxy: bool = False) -> None:
+        type(self).process_calls += 1
+
+    async def get_hostnames(self) -> set[str]:
+        return {'api.example.com'}
+
+    async def get_ips(self) -> set[str]:
+        return {'192.0.2.1'}
+
+
+class DummyBuiltWith:
+    process_calls = 0
+
+    def __init__(self, _domain: str) -> None:
+        pass
+
+    async def process(self, _proxy: bool = False) -> None:
+        type(self).process_calls += 1
+
+    async def get_hostnames(self) -> set[str]:
+        return {'api.example.com'}
+
+    async def get_interestingurls(self) -> set[str]:
+        return {'https://api.example.com/path'}
+
+
+@pytest.mark.parametrize(
+    ('source', 'module_name', 'class_name', 'search_class', 'expected_results'),
+    [
+        (
+            'builtwith',
+            'builtwith',
+            'SearchBuiltWith',
+            DummyBuiltWith,
+            ('api.example.com', 'https://api.example.com/path'),
+        ),
+        ('netlas', 'netlas', 'SearchNetlas', DummyNetlas, ('api.example.com',)),
+        (
+            'securityscorecard',
+            'securityscorecard',
+            'SearchSecurityScorecard',
+            DummySecurityScorecard,
+            ('api.example.com', '192.0.2.1'),
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_cli_requests_only_results_exposed_by_source(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    source: str,
+    module_name: str,
+    class_name: str,
+    search_class: type,
+    expected_results: tuple[str, ...],
+) -> None:
+    import theHarvester.__main__ as main_module
+
+    search_class.process_calls = 0
+    monkeypatch.setattr(main_module.stash, 'StashManager', DummyStashManager)
+    monkeypatch.setattr(getattr(main_module, module_name), class_name, search_class)
+    monkeypatch.setattr(sys, 'argv', ['theHarvester', '-d', 'example.com', '-b', source])
+
+    with pytest.raises(SystemExit) as excinfo:
+        await main_module.start()
+
+    assert excinfo.value.code == 0
+    output = capsys.readouterr().out
+    assert 'AttributeError' not in output
+    assert all(result in output for result in expected_results)
+    assert search_class.process_calls == 1

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -873,7 +873,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                                 netlas_search,
                                 engineitem,
                                 store_host=True,
-                                store_ip=True,
                             )
                         )
                     except Exception as e:
@@ -1012,8 +1011,6 @@ async def start(rest_args: argparse.Namespace | None = None):
                                 engineitem,
                                 store_host=True,
                                 store_ip=True,
-                                store_interestingurls=True,
-                                store_asns=True,
                             )
                         )
                     except Exception as e:
@@ -1877,60 +1874,6 @@ async def start(rest_args: argparse.Namespace | None = None):
             print(f'\n[!] An exception has occurred in API Endpoints scanning: {e}')
             print('    Continuing with the rest of the scan...')
             traceback.print_exc()  # More detailed error information for developers
-
-    if 'securityscorecard' in engines:
-        try:
-            print('\n[*] Performing SecurityScorecard scan...')
-            securityscorecard_scanner = securityscorecard.SearchSecurityScorecard(word)
-            await securityscorecard_scanner.process(use_proxy)
-
-            # Use the existing API to get results
-            hosts = await securityscorecard_scanner.get_hostnames()
-            if hosts:
-                print(f'\n[*] SecurityScorecard results: {len(hosts)} hosts found')
-                for host in hosts:
-                    print(f'    - {host}')
-
-                all_hosts.extend(hosts)
-
-            ips = await securityscorecard_scanner.get_ips()
-            if ips:
-                print(f'\n[*] SecurityScorecard IPs found: {len(ips)}')
-                for ip in ips:
-                    print(f'    - {ip}')
-                all_ip.extend(ips)
-
-        except Exception as e:
-            print(f'An exception has occurred in SecurityScorecard scanning: {e}')
-
-    if 'builtwith' in engines:
-        try:
-            print('\n[*] Performing BuiltWith scan...')
-            builtwith_scanner = builtwith.SearchBuiltWith(word)
-            await builtwith_scanner.process(use_proxy)
-
-            hosts = await builtwith_scanner.get_hostnames()
-            if hosts:
-                print(f'\n[*] BuiltWith results: {len(hosts)} hosts found')
-                for host in hosts:
-                    print(f'    - {host}')
-
-                # Add results to the main host list
-                all_hosts.extend(hosts)
-
-            urls = list(await builtwith_scanner.get_interesting_urls())
-            if urls:
-                print(f'\n[*] BuiltWith interesting URLs found: {len(urls)}')
-                for url in urls:
-                    print(f'    - {url}')
-                interesting_urls.extend(urls)
-
-        except Exception as e:
-            if isinstance(e, MissingKey):
-                if not args.quiet:
-                    print(MissingKey('BuiltWith'))
-                else:
-                    print(f'An exception has occurred in BuiltWith scanning: {e}')
 
     if rest_args is not None:
         all_hosts = sorted({host.replace('www.', '') for host in all_hosts})

--- a/theHarvester/discovery/builtwith.py
+++ b/theHarvester/discovery/builtwith.py
@@ -71,7 +71,7 @@ class SearchBuiltWith:
     async def get_tech_stack(self) -> dict:
         return self.tech_stack
 
-    async def get_interesting_urls(self) -> set[str]:
+    async def get_interestingurls(self) -> set[str]:
         return self.interesting_urls
 
     async def get_frameworks(self) -> set[str]:

--- a/theHarvester/discovery/intelxsearch.py
+++ b/theHarvester/discovery/intelxsearch.py
@@ -1,6 +1,5 @@
 import asyncio
 from typing import Any
-from urllib.parse import urlparse
 
 import aiohttp
 
@@ -70,17 +69,5 @@ class SearchIntelx:
     async def get_emails(self) -> list[str]:
         return self.info[0]
 
-    async def get_interestingurls(self) -> tuple[list[str], list[str]]:
-        urls = self.info[1]
-        subdomains = []
-
-        for url in urls:
-            try:
-                parsed = urlparse(url)
-                domain = parsed.netloc
-                if domain.count('.') > 1 and self.word in domain:
-                    subdomains.append(domain)
-            except Exception:
-                continue
-
-        return urls, list(set(subdomains))
+    async def get_interestingurls(self) -> list[str]:
+        return self.info[1]


### PR DESCRIPTION
## Summary

- align BuiltWith's URL getter with the shared discovery result contract
- stop requesting IP results from Netlas and URL/ASN results from SecurityScorecard when those adapters do not expose them
- return IntelX URLs as the flat collection expected by aggregation
- remove duplicate BuiltWith and SecurityScorecard provider requests
- cover supported CLI results, unsupported result requests, and single-execution behavior with offline regression tests

## Root cause

Source orchestration declared result types independently of the adapters' actual getter contracts. That caused queued work-item `AttributeError`s, malformed IntelX URL aggregation, and duplicate provider requests that could duplicate report data and consume quotas.

## Verification

- focused regression suite: 7 passed
- offline suite excluding the two pre-existing live-network test files: 96 passed
- `ruff check` on changed code and new tests
- `ruff format --check` on all changed files
- `mypy theHarvester`
- `git diff --check`

The full suite was also attempted: 118 passed and 4 skipped; only the existing live Cert Spotter request and THC live-result assertion failed because DNS/network access was unavailable. No live provider traffic is required by the new tests.
