### PR TITLE
Fix delimited provider result parsing

### DIFF
--- a/tests/discovery/test_bufferoverun.py
+++ b/tests/discovery/test_bufferoverun.py
@@ -1,0 +1,28 @@
+import pytest
+
+from theHarvester.discovery import bufferoverun
+from theHarvester.lib.core import Core
+
+
+@pytest.mark.asyncio
+async def test_bufferover_parses_documented_four_column_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Core, 'bufferoverun_key', lambda: 'test-key')
+
+    async def fake_fetch_all(*_args, **_kwargs):
+        return [
+            {
+                'Results': [
+                    '192.0.2.10,hash-1,"Example, Inc.",api.example.com',
+                    '2001:db8::10,hash-2,Example Org,ipv6.example.com',
+                    'malformed,row',
+                ]
+            }
+        ]
+
+    monkeypatch.setattr(bufferoverun.AsyncFetcher, 'fetch_all', fake_fetch_all)
+    search = bufferoverun.SearchBufferover('example.com')
+
+    await search.do_search()
+
+    assert await search.get_hostnames() == {'api.example.com', 'ipv6.example.com'}
+    assert await search.get_ips() == {'192.0.2.10', '2001:db8::10'}

--- a/tests/discovery/test_source_result_contracts.py
+++ b/tests/discovery/test_source_result_contracts.py
@@ -56,6 +56,22 @@ class DummyBuiltWith:
         return {'https://api.example.com/path'}
 
 
+class DummyHackerTarget:
+    process_calls = 0
+
+    def __init__(self, _domain: str) -> None:
+        pass
+
+    async def process(self, _proxy: bool = False) -> None:
+        type(self).process_calls += 1
+
+    async def get_hostnames(self) -> set[str]:
+        return {'api.example.com'}
+
+    async def get_ips(self) -> set[str]:
+        return {'192.0.2.10'}
+
+
 @pytest.mark.parametrize(
     ('source', 'module_name', 'class_name', 'search_class', 'expected_results'),
     [
@@ -73,6 +89,13 @@ class DummyBuiltWith:
             'SearchSecurityScorecard',
             DummySecurityScorecard,
             ('api.example.com', '192.0.2.1'),
+        ),
+        (
+            'hackertarget',
+            'hackertarget',
+            'SearchHackerTarget',
+            DummyHackerTarget,
+            ('api.example.com', '192.0.2.10'),
         ),
     ],
 )

--- a/tests/test_hackertarget_apikey.py
+++ b/tests/test_hackertarget_apikey.py
@@ -1,39 +1,40 @@
-﻿import pytest
+import pytest
+
 from theHarvester.discovery import hackertarget as ht_mod
 from theHarvester.lib.core import Core
 
 
 class TestHackerTargetApiKey:
-
     @pytest.mark.asyncio
     async def test_do_search_with_apikey(self, monkeypatch):
         # make Core.hackertarget_key return a known key
-        monkeypatch.setattr(Core, "hackertarget_key", lambda: "TESTKEY")
+        monkeypatch.setattr(Core, 'hackertarget_key', lambda: 'TESTKEY')
 
         # monkeypatch AsyncFetcher.fetch_all to capture requested URLs
         async def fake_fetch_all(urls, headers=None, proxy=False):
             # ensure apikey present in each URL
-            assert all("apikey=TESTKEY" in u for u in urls)
-            return ["1.2.3.4,host.example.com\n", "No PTR records found\n"]
+            assert all('apikey=TESTKEY' in u for u in urls)
+            return ['host.example.com,1.2.3.4\n', '5.6.7.8,ptr.example.com\n']
 
-        monkeypatch.setattr(ht_mod.AsyncFetcher, "fetch_all", fake_fetch_all)
+        monkeypatch.setattr(ht_mod.AsyncFetcher, 'fetch_all', fake_fetch_all)
 
-        s = ht_mod.SearchHackerTarget("example.com")
+        s = ht_mod.SearchHackerTarget('example.com')
         await s.do_search()
 
-        # after do_search, total_results should include our fake response (commas replaced by colons)
-        assert "1.2.3.4:host.example.com" in s.total_results
+        assert await s.get_hostnames() == {'host.example.com', 'ptr.example.com'}
+        assert await s.get_ips() == {'1.2.3.4', '5.6.7.8'}
 
     @pytest.mark.asyncio
     async def test_do_search_without_apikey(self, monkeypatch):
-        monkeypatch.setattr(Core, "hackertarget_key", lambda: None)
+        monkeypatch.setattr(Core, 'hackertarget_key', lambda: None)
 
         async def fake_fetch_all(urls, headers=None, proxy=False):
-            assert all("apikey=" not in u for u in urls)
-            return ["1.2.3.4,host.example.com\n"]
+            assert all('apikey=' not in u for u in urls)
+            return ['host.example.com,1.2.3.4\n', 'No PTR records found\n']
 
-        monkeypatch.setattr(ht_mod.AsyncFetcher, "fetch_all", fake_fetch_all)
+        monkeypatch.setattr(ht_mod.AsyncFetcher, 'fetch_all', fake_fetch_all)
 
-        s = ht_mod.SearchHackerTarget("example.com")
+        s = ht_mod.SearchHackerTarget('example.com')
         await s.do_search()
-        assert "1.2.3.4:host.example.com" in s.total_results
+        assert await s.get_hostnames() == {'host.example.com'}
+        assert await s.get_ips() == {'1.2.3.4'}

--- a/theHarvester/__main__.py
+++ b/theHarvester/__main__.py
@@ -737,7 +737,7 @@ async def start(rest_args: argparse.Namespace | None = None):
                 elif engineitem == 'hackertarget':
                     try:
                         hackertarget_search = hackertarget.SearchHackerTarget(word)
-                        stor_lst.append(store(hackertarget_search, engineitem, store_host=True))
+                        stor_lst.append(store(hackertarget_search, engineitem, store_host=True, store_ip=True))
                     except Exception as e:
                         show_default_error_message(engineitem, word, e)
 

--- a/theHarvester/discovery/bufferoverun.py
+++ b/theHarvester/discovery/bufferoverun.py
@@ -1,14 +1,21 @@
-import re
+import csv
+import ipaddress
 
 from theHarvester.discovery.constants import MissingKey
 from theHarvester.lib.core import AsyncFetcher, Core
 
 
 class SearchBufferover:
+    """Query BufferOver's documented TLS DNS API.
+
+    Provider API: https://tls.bufferover.run/
+    Result rows: IP, certificate SHA-256, certificate organization, CN/SNI.
+    """
+
     def __init__(self, word) -> None:
         self.word = word
-        self.totalhosts: set = set()
-        self.totalips: set = set()
+        self.totalhosts: set[str] = set()
+        self.totalips: set[str] = set()
         self.key = Core.bufferoverun_key()
         if self.key is None:
             raise MissingKey('bufferoverun')
@@ -22,25 +29,22 @@ class SearchBufferover:
             headers={'User-Agent': Core.get_user_agent(), 'x-api-key': f'{self.key}'},
             proxy=self.proxy,
         )
-        dct = response[0]
-        if dct['Results']:
-            self.totalhosts = {
-                (
-                    host.split(',')
-                    if ',' in host and self.word.replace('www.', '') in host.split(',')[0] in host
-                    else host.split(',')[4]
-                )
-                for host in dct['Results']
-            }
+        for row in csv.reader(response[0].get('Results') or []):
+            if len(row) != 4:
+                continue
+            address, _certificate_hash, _organization, hostname = (value.strip() for value in row)
+            try:
+                ipaddress.ip_address(address)
+            except ValueError:
+                continue
+            self.totalips.add(address)
+            if hostname:
+                self.totalhosts.add(hostname)
 
-        self.totalips = {
-            ip.split(',')[0] for ip in dct['Results'] if re.match(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$', ip.split(',')[0])
-        }
-
-    async def get_hostnames(self) -> set:
+    async def get_hostnames(self) -> set[str]:
         return self.totalhosts
 
-    async def get_ips(self) -> set:
+    async def get_ips(self) -> set[str]:
         return self.totalips
 
     async def process(self, proxy: bool = False) -> None:

--- a/theHarvester/discovery/hackertarget.py
+++ b/theHarvester/discovery/hackertarget.py
@@ -1,17 +1,21 @@
 # theHarvester/discovery/hackertarget.py
+import ipaddress
+
 from theHarvester.lib.core import AsyncFetcher, Core
 
 
 class SearchHackerTarget:
     """Class uses the HackerTarget API to gather subdomains and IPs.
 
-    This version supports reading a Hackertarget API key (if present) and
-    appending it to the hackertarget request URLs as `apikey=<key>`.
+    Provider APIs:
+    https://hackertarget.com/hostsearch/
+    https://hackertarget.com/reverse-dns-lookup/
     """
 
     def __init__(self, word) -> None:
         self.word = word
-        self.total_results = ''
+        self.totalhosts: set[str] = set()
+        self.totalips: set[str] = set()
         self.hostname = 'https://api.hackertarget.com'
         self.proxy = False
         self.results = None
@@ -35,14 +39,29 @@ class SearchHackerTarget:
         # fetch all using existing AsyncFetcher helper
         responses = await AsyncFetcher.fetch_all(request_urls, headers=headers, proxy=self.proxy)
 
-        # the original code concatenated responses and replaced commas with colons
-        for response in responses:
-            # response is expected to be a string; keep the original behavior
-            self.total_results += response.replace(',', ':')
+        for index, response in enumerate(responses[:2]):
+            if not isinstance(response, str):
+                continue
+            for line in response.splitlines():
+                fields = [field.strip() for field in line.split(',', 1)]
+                if len(fields) != 2:
+                    continue
+                hostname, address = fields if index == 0 else fields[::-1]
+                if not hostname:
+                    continue
+                try:
+                    ipaddress.ip_address(address)
+                except ValueError:
+                    continue
+                self.totalhosts.add(hostname)
+                self.totalips.add(address)
 
     async def process(self, proxy: bool = False) -> None:
         self.proxy = proxy
         await self.do_search()
 
-    async def get_hostnames(self) -> list:
-        return [result for result in self.total_results.splitlines() if 'No PTR records found' not in result]
+    async def get_hostnames(self) -> set[str]:
+        return self.totalhosts
+
+    async def get_ips(self) -> set[str]:
+        return self.totalips


### PR DESCRIPTION
## Summary

- parse BufferOver's documented four-column CSV as IP, certificate hash, organization, and CN/SNI
- use the standard-library CSV parser so quoted organizations do not shift columns
- parse HackerTarget Host Search and Reverse DNS rows in their documented opposite field orders
- expose both validated IP addresses and hostnames from HackerTarget through the CLI result path
- cite the first-party provider API pages in the adapter docstrings

## Provider contracts

- BufferOver: https://tls.bufferover.run/
- HackerTarget Host Search: https://hackertarget.com/hostsearch/
- HackerTarget Reverse DNS: https://hackertarget.com/reverse-dns-lookup/

This PR does not add requests, pagination, retries, or new rate-limit assumptions. It only retains both sides of responses already fetched.

## Stack

Base: `codex/report-source-contract` (#90).

If #88 lands first, rebase this branch and update its HackerTarget IP matrix cell in the same PR; the README contract test will enforce that handoff.

## Verification

- 7 focused parser and CLI contract tests pass
- Ruff check and format pass
- `mypy theHarvester` passes

All provider responses are mocked; no live reconnaissance was used.
