### PR TITLE
Harden Python CI and isolate passive provider smoke tests

### DIFF
--- a/.github/workflows/theHarvester.yml
+++ b/.github/workflows/theHarvester.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - '*'
 
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   Python:
     runs-on: ${{ matrix.os }}
@@ -45,64 +50,91 @@ jobs:
       - name: Lint with ruff
         uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
         with:
-          args: check --fix
+          args: check
 
       - name: Format with ruff
         uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
         with:
-          args: format
-
-      - name: Commit changes for ruff formating and linting
-        if: github.event_name == 'push'
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add .
-          git commit -m "Apply ruff fixes and formatting" || true # Use || true to prevent failure if no changes
-          git push origin HEAD:${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          args: format --check
 
       - name: Test with pytest
         run: |
           pytest tests/**
 
-      - name: Run theHarvester module Baidu
+  Passive-provider-smoke:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # IANA-reserved test data; keep this job passive.
+      SMOKE_TEST_DOMAIN: example.com
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: '3.14'
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Install dependencies
         run: |
-          theHarvester -d yale.edu -b baidu
+          sudo mkdir -p /usr/local/etc/theHarvester
+          sudo cp theHarvester/data/*.yaml /usr/local/etc/theHarvester/
+          sudo chown -R runner:runner /usr/local/etc/theHarvester/
+          uv sync --all-groups --frozen
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
+
+      - name: Run theHarvester module Baidu
+        timeout-minutes: 5
+        run: |
+          theHarvester -d "$SMOKE_TEST_DOMAIN" -b baidu
 
       - name: Run theHarvester module CertSpotter
+        timeout-minutes: 5
         run: |
-          theHarvester -d yale.edu -b certspotter
+          theHarvester -d "$SMOKE_TEST_DOMAIN" -b certspotter
 
       - name: Run theHarvester module Crtsh
+        timeout-minutes: 5
         run: |
-          theHarvester -d hcl.com -b crtsh
+          theHarvester -d "$SMOKE_TEST_DOMAIN" -b crtsh
 
       - name: Run theHarvester module DuckDuckGo
+        timeout-minutes: 5
         run: |
-          theHarvester -d yale.edu -b duckduckgo
+          theHarvester -d "$SMOKE_TEST_DOMAIN" -b duckduckgo
 
       - name: Run theHarvester module HackerTarget
+        timeout-minutes: 5
         run: |
-          theHarvester -d yale.edu -b hackertarget
+          theHarvester -d "$SMOKE_TEST_DOMAIN" -b hackertarget
 
       - name: Run theHarvester module Otx
+        timeout-minutes: 5
         run: |
-          theHarvester -d yale.edu -b otx
+          theHarvester -d "$SMOKE_TEST_DOMAIN" -b otx
 
       - name: Run theHarvester module RapidDns
+        timeout-minutes: 5
         run: |
-          theHarvester -d yale.edu -b rapiddns
+          theHarvester -d "$SMOKE_TEST_DOMAIN" -b rapiddns
 
       - name: Run theHarvester module Urlscan
+        timeout-minutes: 5
         run: |
-          theHarvester -d yale.edu -b urlscan
+          theHarvester -d "$SMOKE_TEST_DOMAIN" -b urlscan
 
       - name: Run theHarvester module Yahoo
+        timeout-minutes: 5
         run: |
-          theHarvester -d yale.edu -b yahoo
-
-      - name: Run theHarvester module DNS brute force
-        run: |
-          theHarvester -d yale.edu -c
+          theHarvester -d "$SMOKE_TEST_DOMAIN" -b yahoo


### PR DESCRIPTION
## Summary

- grant the Python workflow only contents: read
- make Ruff lint and formatting check-only, removing CI self-commits and pushes
- move passive provider smoke checks behind manual workflow dispatch
- replace yale.edu and hcl.com with IANA-reserved example.com
- remove live DNS brute force against a public third-party zone
- add job and step timeouts to bound live smoke execution

## Why

Routine pull-request and push CI should be deterministic and read-only. The old workflow mutated the checkout and attempted to push even though checkout credentials were deliberately not persisted. It also queried unrelated third-party domains, including active DNS brute force, on every push and pull request.

Peer review found that Amass and BBOT rely primarily on local servers and mocked network boundaries. Subfinder live tests document provider timeouts, runner blocking, and random failures, which is a pattern to avoid. Passive smoke remains available manually against example.com; active DNS behavior should use a local authoritative DNS fixture or a maintainer-controlled zone.

GitHub documents that once permissions are declared, unspecified permissions become none: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions

IANA example-domain guidance: https://www.iana.org/help/example-domains

## Verification

- YAML parsed successfully
- git diff --check passed
- uv run ruff check . passed
- uv run ruff format --check . passed
- deterministic test subset: 114 passed, 4 skipped, 2 live-network tests deselected
- confirmed no yale.edu, hcl.com, GITHUB_TOKEN, git push, contents: write, or DNS brute-force command remains in this workflow

The two deselected existing tests contact CertSpotter and THC/Tesla directly. They should be converted to mocked or local fixtures separately; no live reconnaissance was performed for this PR.